### PR TITLE
feat: transactionRunner 추가

### DIFF
--- a/src/main/kotlin/com/yapp2app/common/infra/TransactionRunner.kt
+++ b/src/main/kotlin/com/yapp2app/common/infra/TransactionRunner.kt
@@ -1,0 +1,27 @@
+package com.yapp2app.common.infra
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+interface TransactionRunner {
+
+    fun <T> run(func: () -> T): T
+
+    fun <T> readOnly(func: () -> T): T
+
+    fun <T> runNew(func: () -> T): T
+}
+
+@Component
+class TransactionRunnerImpl : TransactionRunner {
+
+    @Transactional
+    override fun <T> run(func: () -> T): T = func()
+
+    @Transactional(readOnly = true)
+    override fun <T> readOnly(func: () -> T): T = func()
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    override fun <T> runNew(func: () -> T): T = func()
+}


### PR DESCRIPTION
## summary
- 트랜잭션 프록시 내부 메서드 호출을 위한 클래스를 추가합니다
- TransactionRunner에게 내부 메서드를 전달하는 방식을 사용해 트랜잭션 애노테이션을 UseCase에서 제거할 수 있습니다
- 이에 따라 private method를 UseCase 내에서 사용 가능합니다
- 필요에 따라 @Transactional과 TransactionRunner를 함께 사용 가능합니다
- 보상 트랜잭션 구현시 활용할 수 있습니다

```kotlin
@UseCase
class RegisterUseCase(
    private val userRepository: UserRepository,
    private val authServiceClient: AuthServiceClient,
    private val transactionRunner: TransactionRunner,
) {
    fun execute(command: CreateUserCommand) {
        val user = transactionRunner.run { registerUser(command) }

        try {
            authServiceClient.notifyUserCreated()
        } catch (ex: Exception) {
            runCatching { transactionRunner.runNew { deleteById(user.id) } }
                .onFailure {
                    logger.error("rollback error", it)
                }
            throw ExternalServiceException()
        }
    }

    private fun registerUser(command: CreateUserCommand): User {
        try {
            val user = User.createUser()

            return userRepository.save(user)
        } catch (ex: DataIntegrityViolationException) {
            throw ConflictException()
        }
    }

    private fun deleteById(userId: Long) {
        userRepository.deleteById(userId)
    }
}

```