### PR TITLE
Fix/#21

### DIFF
--- a/src/main/kotlin/com/yapp2app/common/config/JasyptConfig.kt
+++ b/src/main/kotlin/com/yapp2app/common/config/JasyptConfig.kt
@@ -14,10 +14,10 @@ import org.springframework.context.annotation.Configuration
  * description    : Jasypt 암호화 설정
  */
 @Configuration
-class JasyptConfig {
-
+class JasyptConfig(
     @Value("\${jasypt.encryptor.password}")
-    private lateinit var encryptKey: String
+    private val encryptKey: String,
+) {
 
     @Bean("jasyptStringEncryptor")
     fun stringEncryptor(): StringEncryptor {


### PR DESCRIPTION
<img width="1589" height="484" alt="스크린샷 2025-12-31 오후 7 25 20" src="https://github.com/user-attachments/assets/2deaf79b-9c62-4e4c-8488-78989855ddc8" />

애플리케이션 정상 실행 확인

수정 전 예시
```kotlin
@Configuration
class JasyptConfig {

    @Value("\${jasypt.encryptor.password}")
    lateinit var encryptKey: String

    @Bean
    fun jasyptEncryptor(): StringEncryptor {
        return PooledPBEStringEncryptor().apply {
            setPassword(encryptKey)
        }
    }
}

```

수정 후 예시
```kotlin
@Configuration
class JasyptConfig(
    @Value("\${jasypt.encryptor.password}")
    private val encryptKey: String,
) {

    @Bean
    fun jasyptEncryptor(): StringEncryptor {
        return PooledPBEStringEncryptor().apply {
            setPassword(encryptKey)
        }
    }
}

```
lateinit은 컴파일러 약속일뿐 Spring 라이프사이클이 보장을 해주지 않기 때문에 초기화되지 않은 상태에서 Bean이 생성될 수 있습니다.
생성자 주입을 통해 @Value를 선언하면 명시적으로 환경 변수 주입 이후 Bean이 생성되기 때문에 lateinit보다는 생성자 주입을 통해 환경변수를 주입받는게 안전합니다.

왜 디버깅 모드에서만 이런 에러가 발생하는지는 좀 더 리서치가 필요할 것 같습니다.