### PR TITLE
fix: AuthMdcFilter Authentication type 변경, 테스트 수정

### DIFF
--- a/src/main/kotlin/com/yapp2app/auth/infra/security/filter/AuthMdcFilter.kt
+++ b/src/main/kotlin/com/yapp2app/auth/infra/security/filter/AuthMdcFilter.kt
@@ -27,19 +27,14 @@ class AuthMdcFilter : OncePerRequestFilter() {
         response: HttpServletResponse,
         filterChain: FilterChain,
     ) {
-        // SecurityContext에서 인증 정보 가져오기
         val authentication = SecurityContextHolder.getContext().authentication
 
-        // 인증된 사용자인 경우 MDC에 userId 추가
-        if (authentication != null && authentication.isAuthenticated && authentication.principal != "anonymousUser") {
-            val userPrincipal = authentication.principal as UserPrincipal
-
-            // DB상 name을 가져오는 코드 (택 1)
-            val userId = userPrincipal.id.toString()
-
-            MDC.put(USER_ID, userId)
+        val principal = authentication?.principal
+        if (authentication?.isAuthenticated == true && principal is UserPrincipal) {
+            MDC.put(USER_ID, principal.id.toString())
         }
 
         filterChain.doFilter(request, response)
+        // RequestMdcFilter에서 MDC Context clear
     }
 }

--- a/src/test/kotlin/com/yapp2app/auth/infra/security/filter/AuthMdcFilterTest.kt
+++ b/src/test/kotlin/com/yapp2app/auth/infra/security/filter/AuthMdcFilterTest.kt
@@ -1,6 +1,8 @@
 package com.yapp2app.auth.infra.security.filter
 
+import com.yapp2app.auth.infra.security.token.UserPrincipal
 import com.yapp2app.common.filter.RequestMdcFilter
+import com.yapp2app.user.domain.enums.ProviderType
 import jakarta.servlet.FilterChain
 import jakarta.servlet.ServletRequest
 import jakarta.servlet.ServletResponse
@@ -9,7 +11,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.slf4j.MDC
-import org.springframework.mock.web.MockFilterChain
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
@@ -29,155 +30,105 @@ class AuthMdcFilterTest {
     }
 
     @Test
-    @DisplayName("인증된 사용자의 userId가 MDC에 설정된다")
-    fun givenAuthenticatedUser_whenFilterExecutes_thenSetsUserIdInMdc() {
+    @DisplayName("인증된 UserPrincipal의 userId가 MDC에 설정된다")
+    fun givenAuthenticatedUserPrincipal_whenFilterExecutes_thenSetsUserIdInMdc() {
         // Given
-        val expectedUserId = "user-12345"
-        val authentication = createAuthentication(expectedUserId, authenticated = true)
-        SecurityContextHolder.getContext().authentication = authentication
+        val principal = createUserPrincipal(id = 12345L)
+        SecurityContextHolder.getContext().authentication = authenticatedAuth(principal)
 
-        val request = MockHttpServletRequest()
-        val response = MockHttpServletResponse()
         val filterChain = TestFilterChain()
 
         // When
-        filter.doFilter(request, response, filterChain)
+        filter.doFilter(MockHttpServletRequest(), MockHttpServletResponse(), filterChain)
 
         // Then
-        Assertions.assertThat(filterChain.capturedUserId).isEqualTo(expectedUserId)
+        Assertions.assertThat(filterChain.capturedUserId).isEqualTo("12345")
     }
 
     @Test
-    @DisplayName("익명 사용자일 때 userId가 MDC에 설정되지 않는다")
-    fun givenAnonymousUser_whenFilterExecutes_thenDoesNotSetUserId() {
+    @DisplayName("principal이 UserPrincipal이 아니면 MDC에 userId를 설정하지 않는다")
+    fun givenStringPrincipal_whenFilterExecutes_thenDoesNotSetUserId() {
         // Given
-        val authentication = createAuthentication("anonymousUser", authenticated = true)
-        SecurityContextHolder.getContext().authentication = authentication
+        SecurityContextHolder.getContext().authentication =
+            authenticatedAuth("12345")
 
-        val request = MockHttpServletRequest()
-        val response = MockHttpServletResponse()
         val filterChain = TestFilterChain()
 
         // When
-        filter.doFilter(request, response, filterChain)
+        filter.doFilter(MockHttpServletRequest(), MockHttpServletResponse(), filterChain)
 
         // Then
         Assertions.assertThat(filterChain.capturedUserId).isNull()
     }
 
     @Test
-    @DisplayName("인증되지 않은 사용자일 때 userId가 MDC에 설정되지 않는다")
-    fun givenUnauthenticatedUser_whenFilterExecutes_thenDoesNotSetUserId() {
-        // Given
-        val authentication = createAuthentication("user-12345", authenticated = false)
-        SecurityContextHolder.getContext().authentication = authentication
-
-        val request = MockHttpServletRequest()
-        val response = MockHttpServletResponse()
-        val filterChain = TestFilterChain()
-
-        // When
-        filter.doFilter(request, response, filterChain)
-
-        // Then
-        Assertions.assertThat(filterChain.capturedUserId).isNull()
-    }
-
-    @Test
-    @DisplayName("인증 정보가 없을 때 userId가 MDC에 설정되지 않는다")
+    @DisplayName("Authentication이 없으면 MDC에 userId를 설정하지 않는다")
     fun givenNoAuthentication_whenFilterExecutes_thenDoesNotSetUserId() {
-        // Given - SecurityContext에 인증 정보 없음
-        val request = MockHttpServletRequest()
-        val response = MockHttpServletResponse()
         val filterChain = TestFilterChain()
 
-        // When
-        filter.doFilter(request, response, filterChain)
+        filter.doFilter(MockHttpServletRequest(), MockHttpServletResponse(), filterChain)
 
-        // Then
         Assertions.assertThat(filterChain.capturedUserId).isNull()
     }
 
     @Test
-    @DisplayName("필터 체인이 정상적으로 실행된다")
-    fun givenRequest_whenFilterExecutes_thenContinuesFilterChain() {
+    @DisplayName("기존 MDC 값(requestId)을 유지하면서 userId를 추가한다")
+    fun givenExistingMdc_whenFilterExecutes_thenPreservesValues() {
         // Given
-        val authentication = createAuthentication("user-12345", authenticated = true)
-        SecurityContextHolder.getContext().authentication = authentication
+        MDC.put(RequestMdcFilter.REQUEST_ID, "req-123")
 
-        val request = MockHttpServletRequest()
-        val response = MockHttpServletResponse()
-        val filterChain = MockFilterChain()
+        val principal = createUserPrincipal(id = 99L)
+        SecurityContextHolder.getContext().authentication = authenticatedAuth(principal)
 
-        // When
-        filter.doFilter(request, response, filterChain)
-
-        // Then - 필터 체인이 실행되었는지 확인
-        Assertions.assertThat(filterChain.request).isEqualTo(request)
-        Assertions.assertThat(filterChain.response).isEqualTo(response)
-    }
-
-    @Test
-    @DisplayName("권한이 있는 인증된 사용자의 userId가 MDC에 설정된다")
-    fun givenAuthenticatedUserWithAuthorities_whenFilterExecutes_thenSetsUserIdInMdc() {
-        // Given
-        val expectedUserId = "admin-99999"
-        val authorities = listOf(
-            SimpleGrantedAuthority("ROLE_ADMIN"),
-            SimpleGrantedAuthority("ROLE_USER"),
-        )
-        val authentication = UsernamePasswordAuthenticationToken(
-            expectedUserId,
-            "password",
-            authorities,
-        )
-        SecurityContextHolder.getContext().authentication = authentication
-
-        val request = MockHttpServletRequest()
-        val response = MockHttpServletResponse()
         val filterChain = TestFilterChain()
 
         // When
-        filter.doFilter(request, response, filterChain)
+        filter.doFilter(MockHttpServletRequest(), MockHttpServletResponse(), filterChain)
 
         // Then
-        Assertions.assertThat(filterChain.capturedUserId).isEqualTo(expectedUserId)
+        Assertions.assertThat(filterChain.capturedRequestId).isEqualTo("req-123")
+        Assertions.assertThat(filterChain.capturedUserId).isEqualTo("99")
     }
 
     @Test
-    @DisplayName("다른 필터에서 설정한 MDC 값을 유지한다")
+    @DisplayName("다른 필터에서 설정한 MDC 값을 유지하면서 userId를 추가한다")
     fun givenExistingMdcValues_whenFilterExecutes_thenPreservesExistingValues() {
         // Given
         val expectedRequestId = "request-id-12345"
-        MDC.put(RequestMdcFilter.Companion.REQUEST_ID, expectedRequestId)
+        MDC.put(RequestMdcFilter.REQUEST_ID, expectedRequestId)
 
-        val expectedUserId = "user-12345"
-        val authentication = createAuthentication(expectedUserId, authenticated = true)
-        SecurityContextHolder.getContext().authentication = authentication
+        val principal = createUserPrincipal(id = 12345L)
+        SecurityContextHolder.getContext().authentication =
+            authenticatedAuth(principal)
 
-        val request = MockHttpServletRequest()
-        val response = MockHttpServletResponse()
         val filterChain = TestFilterChain()
 
         // When
-        filter.doFilter(request, response, filterChain)
+        filter.doFilter(MockHttpServletRequest(), MockHttpServletResponse(), filterChain)
 
         // Then
         Assertions.assertThat(filterChain.capturedRequestId).isEqualTo(expectedRequestId)
-        Assertions.assertThat(filterChain.capturedUserId).isEqualTo(expectedUserId)
+        Assertions.assertThat(filterChain.capturedUserId).isEqualTo("12345")
     }
 
     /**
      * 테스트용 Authentication 객체 생성
      */
-    private fun createAuthentication(username: String, authenticated: Boolean): UsernamePasswordAuthenticationToken =
-        if (authenticated) {
-            // authenticated = true: authorities를 포함하는 생성자 사용
-            UsernamePasswordAuthenticationToken(username, "password", emptyList())
-        } else {
-            // authenticated = false: authorities를 포함하지 않는 생성자 사용
-            UsernamePasswordAuthenticationToken(username, "password")
-        }
+    private fun createUserPrincipal(id: Long = 1L): UserPrincipal = UserPrincipal(
+        id = id,
+        name = "test-user",
+        providerType = ProviderType.LOCAL,
+        email = "test@test.com",
+        roles = setOf("ROLE_USER"),
+        password = "NO_PASS",
+    )
+
+    private fun authenticatedAuth(principal: Any): UsernamePasswordAuthenticationToken =
+        UsernamePasswordAuthenticationToken(
+            principal,
+            null,
+            listOf(SimpleGrantedAuthority("ROLE_USER")),
+        )
 
     /**
      * FilterChain 실행 중 MDC 값을 캡처하는 테스트용 FilterChain


### PR DESCRIPTION
## summary
- AuthMdcFilter의 authentication type 수정
- AuthMdcFilter 단위 테스트 수정

## details
- AuthMdcFilter에서 SecurityContextHolder의 Authentication이 String으로 잘못 캐스팅되는 문제 수정
- AuthMdcFilter 단위 테스트의 불필요한 테스트를 제거하고, 타입 캐스팅 관련 테스트를 수정