### PR TITLE
Feat/#97 : 회원탈퇴

### DIFF
--- a/src/main/kotlin/com/yapp2app/user/api/controller/UserController.kt
+++ b/src/main/kotlin/com/yapp2app/user/api/controller/UserController.kt
@@ -6,11 +6,13 @@ import com.yapp2app.user.api.converter.UserCommandConverter
 import com.yapp2app.user.api.converter.UserResultConverter
 import com.yapp2app.user.api.dto.GetUserResponse
 import com.yapp2app.user.api.dto.UpdateUserRequest
+import com.yapp2app.user.application.usecase.DeleteMeUseCase
 import com.yapp2app.user.application.usecase.GetUserInfoUseCase
 import com.yapp2app.user.application.usecase.UpdateMeUseCase
 import io.swagger.v3.oas.annotations.Operation
 import jakarta.validation.Valid
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -29,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController
 class UserController(
     private val updateMeUseCase: UpdateMeUseCase,
     private val getUserInfoUseCase: GetUserInfoUseCase,
+    private val deleteMeUseCase: DeleteMeUseCase,
 
     private val commandConverter: UserCommandConverter,
     private val resultConverter: UserResultConverter,
@@ -69,6 +72,19 @@ class UserController(
         val command = commandConverter.toUpdateUserCommand(userId, request)
 
         updateMeUseCase.execute(command)
+
+        return BaseResponse()
+    }
+
+    @Operation(
+        summary = "회원탈퇴",
+        description = "회원탈퇴를 진행합니다.",
+    )
+    @DeleteMapping("/me")
+    fun deleteMe(@AuthenticationPrincipal(expression = "id") userId: Long): BaseResponse<Any> {
+        val command = commandConverter.toDeleteUserCommand(userId)
+
+        deleteMeUseCase.execute(command)
 
         return BaseResponse()
     }

--- a/src/main/kotlin/com/yapp2app/user/api/converter/UserCommandConverter.kt
+++ b/src/main/kotlin/com/yapp2app/user/api/converter/UserCommandConverter.kt
@@ -1,6 +1,7 @@
 package com.yapp2app.user.api.converter
 
 import com.yapp2app.user.api.dto.UpdateUserRequest
+import com.yapp2app.user.application.command.DeleteUserCommand
 import com.yapp2app.user.application.command.GetUserCommand
 import com.yapp2app.user.application.command.UpdateUserCommand
 import org.springframework.stereotype.Component
@@ -18,4 +19,6 @@ class UserCommandConverter {
 
     fun toUpdateUserCommand(userId: Long, request: UpdateUserRequest) =
         UpdateUserCommand(userId, request.mediaId, request.name)
+
+    fun toDeleteUserCommand(userId: Long) = DeleteUserCommand(userId)
 }

--- a/src/main/kotlin/com/yapp2app/user/application/command/UserCommand.kt
+++ b/src/main/kotlin/com/yapp2app/user/application/command/UserCommand.kt
@@ -9,3 +9,5 @@ package com.yapp2app.user.application.command
 data class GetUserCommand(val userId: Long)
 
 data class UpdateUserCommand(val userId: Long, val mediaId: Long?, val name: String)
+
+data class DeleteUserCommand(val userId: Long)

--- a/src/main/kotlin/com/yapp2app/user/application/usecase/DeleteMeUseCase.kt
+++ b/src/main/kotlin/com/yapp2app/user/application/usecase/DeleteMeUseCase.kt
@@ -1,0 +1,28 @@
+package com.yapp2app.user.application.usecase
+
+import com.yapp2app.common.annotation.UseCase
+import com.yapp2app.common.api.dto.ResultCode
+import com.yapp2app.common.exception.BusinessException
+import com.yapp2app.user.application.command.DeleteUserCommand
+import com.yapp2app.user.application.port.UserRepositoryPort
+import com.yapp2app.user.domain.entity.User
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * fileName       : DeleteMeUseCase
+ * author         : koo
+ * date           : 2026. 1. 30. 오후 5:49
+ * description    : 회원탍퇴 usecase
+ * - 회원 탈퇴 시, 사용자 정보는 삭제하지 않고 상태만 '탈퇴'로 변경
+ */
+@UseCase
+class DeleteMeUseCase(private val userRepository: UserRepositoryPort) {
+
+    @Transactional
+    fun execute(command: DeleteUserCommand) {
+        val user: User = userRepository.findById(command.userId)
+            ?: throw BusinessException(ResultCode.NOT_FOUND_USER)
+
+        user.withdraw()
+    }
+}

--- a/src/main/kotlin/com/yapp2app/user/domain/entity/User.kt
+++ b/src/main/kotlin/com/yapp2app/user/domain/entity/User.kt
@@ -21,13 +21,13 @@ class User(
     val id: Long? = null,
 
     @Column(nullable = false)
-    val email: String?,
+    var email: String?,
 
     @Column(nullable = true)
     var password: String,
 
-    @Column(nullable = false, length = 255)
-    val oid: String,
+    @Column(nullable = true, length = 255)
+    var oid: String?,
 
     @Column(nullable = false, length = 100)
     var name: String?,
@@ -62,5 +62,10 @@ class User(
     fun updateInfo(name: String, newProfileImageId: Long?) {
         this.name = name
         this.profileImageId = newProfileImageId
+    }
+
+    fun withdraw() {
+        this.email = null
+        this.oid = null
     }
 }


### PR DESCRIPTION
## summary
- 회원탈퇴 API

## details
회원탈퇴를 진행합니다. 기존 리소스를 삭제하지 않고, oid와 email만을 삭제합니다. 회원탈퇴 후 다시 회원가입을 진행하는 경우 기존 리소스에 대한 접근을 할 수 없습니다. 회원가입을 다시 하는 경우 email 정보가 남아있으면 unique key 제약 조건으로 실패하여 email도 null로 변경하도록 구현했습니다.

c.c. tb_users 테이블의 email과 oid의 not null 제약 조건을 없애햐 합니다.
```sql
-- email not null 제거
alter table tb_users
alter column email drop not null;

-- oid not null 제거
alter table tb_users
alter column oid drop not null;
```