### PR TITLE
fix/#109: 브랜드 목록 조회시 id순으로 오름차순 정렬

### DIFF
--- a/src/main/kotlin/com/yapp2app/map/infra/persist/BrandRepositoryAdapter.kt
+++ b/src/main/kotlin/com/yapp2app/map/infra/persist/BrandRepositoryAdapter.kt
@@ -16,5 +16,5 @@ class BrandRepositoryAdapter(private val jpaRepository: JpaBrandRepository) : Br
 
     override fun getBrand(code: String): Brand? = jpaRepository.findByCode(code)
 
-    override fun findAll(): List<Brand> = jpaRepository.findAll()
+    override fun findAll(): List<Brand> = jpaRepository.findAllByOrderByIdAsc()
 }

--- a/src/main/kotlin/com/yapp2app/map/infra/persist/jpa/JpaBrandRepository.kt
+++ b/src/main/kotlin/com/yapp2app/map/infra/persist/jpa/JpaBrandRepository.kt
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository
  * description    : Brand JPA Repository
  */
 interface JpaBrandRepository : JpaRepository<Brand, Long> {
+    fun findAllByOrderByIdAsc(): List<Brand>
 
     fun findByCode(code: String): Brand?
 }


### PR DESCRIPTION
## Description
- PostgreSQL(그리고 대부분의 RDBMS)은 ORDER BY 없이 조회하면 순서를 보장하지 않습니다. 
- 기획상 부스수가 많은 순서로 보여줘야하기 때문에 정렬쿼리 추가

## Action Item
- [x] brandRepository에 ByOrderByIdAsc() 추가