### PR TITLE
Fix/#105: 사용자 닉네임 제약 조건 추가

### DIFF
--- a/src/main/kotlin/com/yapp2app/user/api/dto/UserRequest.kt
+++ b/src/main/kotlin/com/yapp2app/user/api/dto/UserRequest.kt
@@ -13,7 +13,7 @@ import jakarta.validation.constraints.Size
 data class UpdateUserRequest(
     @field:Schema(description = "공백을 포함해 12글자 이하로 변경할 닉네임을 설정합니다", example = "새로운닉네임")
     @field:Size(max = 12, message = "닉네임은 공백 포함 12자 이하여야 합니다.")
-    @field:NotBlank(message = "닉네임은 공백 포함 12자 이하여야 합니다")
+    @field:NotBlank(message = "닉네임은 공백일 수 없습니다")
     val name: String,
 )
 

--- a/src/main/kotlin/com/yapp2app/user/api/dto/UserRequest.kt
+++ b/src/main/kotlin/com/yapp2app/user/api/dto/UserRequest.kt
@@ -11,9 +11,9 @@ import jakarta.validation.constraints.Size
  * description    :
  */
 data class UpdateUserRequest(
-    @field:Schema(description = "공백을 포함해 10글자 이하로 변경할 닉네임을 설정합니다", example = "새로운닉네임")
-    @field:Size(max = 10, message = "닉네임은 공백 포함 10자 이하여야 합니다.")
-    @field:NotBlank(message = "닉네임은 공백 포함 10자 이하여야 합니다")
+    @field:Schema(description = "공백을 포함해 12글자 이하로 변경할 닉네임을 설정합니다", example = "새로운닉네임")
+    @field:Size(max = 12, message = "닉네임은 공백 포함 12자 이하여야 합니다.")
+    @field:NotBlank(message = "닉네임은 공백 포함 12자 이하여야 합니다")
     val name: String,
 )
 

--- a/src/main/kotlin/com/yapp2app/user/domain/entity/User.kt
+++ b/src/main/kotlin/com/yapp2app/user/domain/entity/User.kt
@@ -29,7 +29,7 @@ class User(
     @Column(nullable = true, length = 255)
     var oid: String?,
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, length = 12)
     var name: String?,
 
     @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/com/yapp2app/user/infra/generator/NicknameGenerator.kt
+++ b/src/main/kotlin/com/yapp2app/user/infra/generator/NicknameGenerator.kt
@@ -15,9 +15,9 @@ class NicknameGenerator(private val userRepository: UserRepository) : NicknameGe
 
     companion object {
         private val ADJECTIVES = listOf(
-            "사진찍는", "셔터누른", "포커스맞춘", "순간담은", "기록하는",
+            "사진찍는", "셔터누른", "순간담은", "기록하는",
             "스냅찍는", "빛나는", "반짝이는", "선명한", "아련한",
-            "감성적인", "필름같은", "빈티지한", "자연스러운",
+            "감성적인", "필름같은", "빈티지한",
         )
 
         private val NOUNS = listOf(
@@ -27,9 +27,9 @@ class NicknameGenerator(private val userRepository: UserRepository) : NicknameGe
         )
 
         private const val MAX_RETRY_COUNT = 10
-        private const val MIN_NUMBER = 100
-        private const val MAX_NUMBER = 999
-        private const val FALLBACK_MODULO = 1000000
+        private const val MIN_NUMBER = 1
+        private const val MAX_NUMBER = 99
+        private const val FALLBACK_MODULO = 100
     }
 
     override fun generateUniqueNickname(): String {
@@ -45,7 +45,7 @@ class NicknameGenerator(private val userRepository: UserRepository) : NicknameGe
             }
         }
 
-        // fallback: 타임스탬프 기반 6자리
+        // fallback: 타임스탬프 기반 2자리
         return "$baseName-${System.currentTimeMillis() % FALLBACK_MODULO}"
     }
 }

--- a/src/main/resources/db/migration/V6__alter_users_name_length.sql
+++ b/src/main/resources/db/migration/V6__alter_users_name_length.sql
@@ -1,0 +1,2 @@
+-- 사용자 닉네임 최대 길이를 12자로 제한
+ALTER TABLE TB_USERS ALTER COLUMN name TYPE VARCHAR(12);


### PR DESCRIPTION
# summary
- 사용자 닉네임 길이 제한을 12자로 변경
- 사용자 닉네임 생성 로직에서 글자 수가 12글자를 넘지 않도록 수정