### PR TITLE
Fix/#116: 약관 목록 및 약관 동의 기능 개발

### DIFF
--- a/src/main/kotlin/com/yapp2app/auth/infra/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/yapp2app/auth/infra/security/config/SecurityConfig.kt
@@ -64,7 +64,7 @@ class SecurityConfig(private val corsConfigurationSource: CorsConfigurationSourc
         .csrf { it.disable() }
         .cors { it.configurationSource(corsConfigurationSource) }
         .authorizeHttpRequests {
-            it.requestMatchers("/api/auth/**", "/api/users/register", "/api/versions/**").permitAll()
+            it.requestMatchers("/api/auth/**", "/api/users/register", "/api/versions/**", "/api/terms").permitAll()
             it.requestMatchers("/api/poses/admin/upload").hasRole("ADMIN")
             it.anyRequest().authenticated()
         }

--- a/src/main/kotlin/com/yapp2app/common/api/dto/ResultCode.kt
+++ b/src/main/kotlin/com/yapp2app/common/api/dto/ResultCode.kt
@@ -17,6 +17,7 @@ enum class ResultCode(val code: String, val message: String) {
     NOT_FOUND("D-04", "데이터를 찾을 수 없습니다."),
     ALREADY_REQUEST("D-05", "이미 처리된 요청입니다."),
     UPLOAD_FAILED("D-06", "파일 업로드에 실패했습니다."),
+    REQUIRED_TERMS_NOT_AGREED("D-07", "필수 약관에 동의해주세요."),
 
     CONFLICT_FOLDER("D-06", message = "해당하는 폴더가 존재합니다."),
 

--- a/src/main/kotlin/com/yapp2app/term/api/controller/TermController.kt
+++ b/src/main/kotlin/com/yapp2app/term/api/controller/TermController.kt
@@ -50,7 +50,7 @@ class TermController(
         @Valid @RequestBody request: CreateTermAgreementsRequest,
     ): BaseResponse<Any> {
         val command = commandConverter.toCreateTermAgreementsCommand(userId, request)
-        val result = createTermAgreementsUseCase.execute(command)
+        createTermAgreementsUseCase.execute(command)
         return BaseResponse()
     }
 }

--- a/src/main/kotlin/com/yapp2app/term/api/controller/TermController.kt
+++ b/src/main/kotlin/com/yapp2app/term/api/controller/TermController.kt
@@ -1,0 +1,56 @@
+package com.yapp2app.term.api.controller
+
+import com.yapp2app.common.api.document.RequiresSecurity
+import com.yapp2app.common.api.dto.BaseResponse
+import com.yapp2app.term.api.converter.TermCommandConverter
+import com.yapp2app.term.api.converter.TermResultConverter
+import com.yapp2app.term.api.dto.CreateTermAgreementsRequest
+import com.yapp2app.term.api.dto.GetTermsResponse
+import com.yapp2app.term.application.usecase.CreateTermAgreementsUseCase
+import com.yapp2app.term.application.usecase.GetTermsUseCase
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Term", description = "약관 API")
+@RestController
+@RequestMapping("/api/terms")
+class TermController(
+    private val getTermsUseCase: GetTermsUseCase,
+    private val createTermAgreementsUseCase: CreateTermAgreementsUseCase,
+    private val commandConverter: TermCommandConverter,
+    private val resultConverter: TermResultConverter,
+) {
+
+    @Operation(
+        summary = "약관 목록 조회",
+        description = "현재 활성화된 약관 목록을 조회합니다.",
+    )
+    @GetMapping
+    fun getTerms(): BaseResponse<GetTermsResponse> {
+        val result = getTermsUseCase.execute()
+        val response = resultConverter.toGetTermsResponse(result)
+        return BaseResponse(data = response)
+    }
+
+    @RequiresSecurity
+    @Operation(
+        summary = "약관 동의",
+        description = "약관에 동의합니다. 필수 약관에 모두 동의해야 합니다.",
+    )
+    @PostMapping("/agreements")
+    fun createTermAgreements(
+        @AuthenticationPrincipal(expression = "id") userId: Long,
+        @Valid @RequestBody request: CreateTermAgreementsRequest,
+    ): BaseResponse<Any> {
+        val command = commandConverter.toCreateTermAgreementsCommand(userId, request)
+        val result = createTermAgreementsUseCase.execute(command)
+        return BaseResponse()
+    }
+}

--- a/src/main/kotlin/com/yapp2app/term/api/converter/TermCommandConverter.kt
+++ b/src/main/kotlin/com/yapp2app/term/api/converter/TermCommandConverter.kt
@@ -1,0 +1,21 @@
+package com.yapp2app.term.api.converter
+
+import com.yapp2app.term.api.dto.CreateTermAgreementsRequest
+import com.yapp2app.term.application.command.CreateTermAgreementsCommand
+import com.yapp2app.term.application.command.TermAgreementItem
+import org.springframework.stereotype.Component
+
+@Component
+class TermCommandConverter {
+
+    fun toCreateTermAgreementsCommand(userId: Long, request: CreateTermAgreementsRequest): CreateTermAgreementsCommand =
+        CreateTermAgreementsCommand(
+            userId = userId,
+            agreements = request.agreements.map { item ->
+                TermAgreementItem(
+                    termId = item.termId,
+                    agreed = item.agreed,
+                )
+            },
+        )
+}

--- a/src/main/kotlin/com/yapp2app/term/api/converter/TermResultConverter.kt
+++ b/src/main/kotlin/com/yapp2app/term/api/converter/TermResultConverter.kt
@@ -1,0 +1,23 @@
+package com.yapp2app.term.api.converter
+
+import com.yapp2app.term.api.dto.GetTermsResponse
+import com.yapp2app.term.api.dto.TermInfoResponse
+import com.yapp2app.term.application.result.GetTermsResult
+import org.springframework.stereotype.Component
+
+@Component
+class TermResultConverter {
+
+    fun toGetTermsResponse(result: GetTermsResult): GetTermsResponse = GetTermsResponse(
+        terms = result.terms.map { termInfo ->
+            TermInfoResponse(
+                id = termInfo.id,
+                termType = termInfo.termType.name,
+                title = termInfo.title,
+                url = termInfo.url,
+                version = termInfo.version,
+                isRequired = termInfo.isRequired,
+            )
+        },
+    )
+}

--- a/src/main/kotlin/com/yapp2app/term/api/converter/TermResultConverter.kt
+++ b/src/main/kotlin/com/yapp2app/term/api/converter/TermResultConverter.kt
@@ -15,7 +15,6 @@ class TermResultConverter {
                 termType = termInfo.termType.name,
                 title = termInfo.title,
                 url = termInfo.url,
-                version = termInfo.version,
                 isRequired = termInfo.isRequired,
             )
         },

--- a/src/main/kotlin/com/yapp2app/term/api/dto/TermRequest.kt
+++ b/src/main/kotlin/com/yapp2app/term/api/dto/TermRequest.kt
@@ -1,0 +1,20 @@
+package com.yapp2app.term.api.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotEmpty
+
+data class CreateTermAgreementsRequest(
+    @field:Valid
+    @field:NotEmpty(message = "약관 동의 항목이 비어있습니다.")
+    @field:Schema(description = "약관 동의 항목 목록")
+    val agreements: List<TermAgreementItemRequest>,
+)
+
+data class TermAgreementItemRequest(
+    @field:Schema(description = "약관 ID", example = "1")
+    val termId: Long,
+
+    @field:Schema(description = "동의 여부", example = "true")
+    val agreed: Boolean,
+)

--- a/src/main/kotlin/com/yapp2app/term/api/dto/TermResponse.kt
+++ b/src/main/kotlin/com/yapp2app/term/api/dto/TermResponse.kt
@@ -1,0 +1,28 @@
+package com.yapp2app.term.api.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class GetTermsResponse(
+    @field:Schema(description = "약관 목록")
+    val terms: List<TermInfoResponse>,
+)
+
+data class TermInfoResponse(
+    @field:Schema(description = "약관 ID", example = "1")
+    val id: Long,
+
+    @field:Schema(description = "약관 종류", example = "SERVICE")
+    val termType: String,
+
+    @field:Schema(description = "약관 제목", example = "서비스 이용약관")
+    val title: String,
+
+    @field:Schema(description = "약관 URL", example = "https://example.com/terms/service")
+    val url: String,
+
+    @field:Schema(description = "약관 버전", example = "1.0.0")
+    val version: String,
+
+    @field:Schema(description = "필수 동의 여부", example = "true")
+    val isRequired: Boolean,
+)

--- a/src/main/kotlin/com/yapp2app/term/api/dto/TermResponse.kt
+++ b/src/main/kotlin/com/yapp2app/term/api/dto/TermResponse.kt
@@ -20,9 +20,6 @@ data class TermInfoResponse(
     @field:Schema(description = "약관 URL", example = "https://example.com/terms/service")
     val url: String,
 
-    @field:Schema(description = "약관 버전", example = "1.0.0")
-    val version: String,
-
     @field:Schema(description = "필수 동의 여부", example = "true")
     val isRequired: Boolean,
 )

--- a/src/main/kotlin/com/yapp2app/term/application/command/TermCommand.kt
+++ b/src/main/kotlin/com/yapp2app/term/application/command/TermCommand.kt
@@ -1,0 +1,7 @@
+package com.yapp2app.term.application.command
+
+data class CreateTermAgreementsCommand(val userId: Long, val agreements: List<TermAgreementItem>)
+
+data class TermAgreementItem(val termId: Long, val agreed: Boolean)
+
+data class CheckLatestTermsAgreementCommand(val userId: Long)

--- a/src/main/kotlin/com/yapp2app/term/application/port/TermRepositoryPort.kt
+++ b/src/main/kotlin/com/yapp2app/term/application/port/TermRepositoryPort.kt
@@ -1,0 +1,11 @@
+package com.yapp2app.term.application.port
+
+import com.yapp2app.term.domain.entity.Term
+
+interface TermRepositoryPort {
+    fun findAllActiveTerms(): List<Term>
+
+    fun findById(id: Long): Term?
+
+    fun findAllByIds(ids: List<Long>): List<Term>
+}

--- a/src/main/kotlin/com/yapp2app/term/application/port/UserTermAgreementRepositoryPort.kt
+++ b/src/main/kotlin/com/yapp2app/term/application/port/UserTermAgreementRepositoryPort.kt
@@ -1,0 +1,9 @@
+package com.yapp2app.term.application.port
+
+import com.yapp2app.term.domain.entity.UserTermAgreement
+
+interface UserTermAgreementRepositoryPort {
+    fun findByUserId(userId: Long): List<UserTermAgreement>
+
+    fun saveAll(agreements: List<UserTermAgreement>): List<UserTermAgreement>
+}

--- a/src/main/kotlin/com/yapp2app/term/application/result/TermResult.kt
+++ b/src/main/kotlin/com/yapp2app/term/application/result/TermResult.kt
@@ -9,7 +9,6 @@ data class TermInfo(
     val termType: TermType,
     val title: String,
     val url: String,
-    val version: String,
     val isRequired: Boolean,
 )
 

--- a/src/main/kotlin/com/yapp2app/term/application/result/TermResult.kt
+++ b/src/main/kotlin/com/yapp2app/term/application/result/TermResult.kt
@@ -1,0 +1,16 @@
+package com.yapp2app.term.application.result
+
+import com.yapp2app.term.domain.enums.TermType
+
+data class GetTermsResult(val terms: List<TermInfo>)
+
+data class TermInfo(
+    val id: Long,
+    val termType: TermType,
+    val title: String,
+    val url: String,
+    val version: String,
+    val isRequired: Boolean,
+)
+
+data class CheckLatestTermsAgreementResult(val hasAgreedToLatestTerms: Boolean)

--- a/src/main/kotlin/com/yapp2app/term/application/result/TermResult.kt
+++ b/src/main/kotlin/com/yapp2app/term/application/result/TermResult.kt
@@ -4,12 +4,6 @@ import com.yapp2app.term.domain.enums.TermType
 
 data class GetTermsResult(val terms: List<TermInfo>)
 
-data class TermInfo(
-    val id: Long,
-    val termType: TermType,
-    val title: String,
-    val url: String,
-    val isRequired: Boolean,
-)
+data class TermInfo(val id: Long, val termType: TermType, val title: String, val url: String, val isRequired: Boolean)
 
 data class CheckLatestTermsAgreementResult(val hasAgreedToLatestTerms: Boolean)

--- a/src/main/kotlin/com/yapp2app/term/application/usecase/CheckLatestTermsAgreementUseCase.kt
+++ b/src/main/kotlin/com/yapp2app/term/application/usecase/CheckLatestTermsAgreementUseCase.kt
@@ -16,10 +16,9 @@ class CheckLatestTermsAgreementUseCase(
         val activeTerms = termRepository.findAllActiveTerms()
         val userAgreements = userTermAgreementRepository.findByUserId(command.userId)
 
+        val agreedTermVersions = userAgreements.map { it.id.termId to it.termVersion }.toSet()
         val hasAgreedToLatestTerms = activeTerms.all { term ->
-            userAgreements.any { agreement ->
-                agreement.id.termId == term.id && agreement.termVersion == term.version
-            }
+            (term.id to term.version) in agreedTermVersions
         }
 
         return CheckLatestTermsAgreementResult(hasAgreedToLatestTerms = hasAgreedToLatestTerms)

--- a/src/main/kotlin/com/yapp2app/term/application/usecase/CheckLatestTermsAgreementUseCase.kt
+++ b/src/main/kotlin/com/yapp2app/term/application/usecase/CheckLatestTermsAgreementUseCase.kt
@@ -1,0 +1,27 @@
+package com.yapp2app.term.application.usecase
+
+import com.yapp2app.common.annotation.UseCase
+import com.yapp2app.term.application.command.CheckLatestTermsAgreementCommand
+import com.yapp2app.term.application.port.TermRepositoryPort
+import com.yapp2app.term.application.port.UserTermAgreementRepositoryPort
+import com.yapp2app.term.application.result.CheckLatestTermsAgreementResult
+
+@UseCase
+class CheckLatestTermsAgreementUseCase(
+    private val termRepository: TermRepositoryPort,
+    private val userTermAgreementRepository: UserTermAgreementRepositoryPort,
+) {
+
+    fun execute(command: CheckLatestTermsAgreementCommand): CheckLatestTermsAgreementResult {
+        val activeTerms = termRepository.findAllActiveTerms()
+        val userAgreements = userTermAgreementRepository.findByUserId(command.userId)
+
+        val hasAgreedToLatestTerms = activeTerms.all { term ->
+            userAgreements.any { agreement ->
+                agreement.id.termId == term.id && agreement.termVersion == term.version
+            }
+        }
+
+        return CheckLatestTermsAgreementResult(hasAgreedToLatestTerms = hasAgreedToLatestTerms)
+    }
+}

--- a/src/main/kotlin/com/yapp2app/term/application/usecase/CreateTermAgreementsUseCase.kt
+++ b/src/main/kotlin/com/yapp2app/term/application/usecase/CreateTermAgreementsUseCase.kt
@@ -1,0 +1,47 @@
+package com.yapp2app.term.application.usecase
+
+import com.yapp2app.common.annotation.UseCase
+import com.yapp2app.common.api.dto.ResultCode
+import com.yapp2app.common.exception.BusinessException
+import com.yapp2app.term.application.command.CreateTermAgreementsCommand
+import com.yapp2app.term.application.port.TermRepositoryPort
+import com.yapp2app.term.application.port.UserTermAgreementRepositoryPort
+import com.yapp2app.term.domain.entity.UserTermAgreement
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@UseCase
+class CreateTermAgreementsUseCase(
+    private val termRepository: TermRepositoryPort,
+    private val userTermAgreementRepository: UserTermAgreementRepositoryPort,
+) {
+
+    @Transactional
+    fun execute(command: CreateTermAgreementsCommand) {
+        val agreedTermIds = command.agreements
+            .filter { it.agreed }
+            .map { it.termId }
+
+        val requiredTerms = termRepository.findAllActiveTerms()
+            .filter { it.isRequired }
+
+        val missingRequired = requiredTerms.filter { it.id !in agreedTermIds }
+        if (missingRequired.isNotEmpty()) {
+            throw BusinessException(ResultCode.REQUIRED_TERMS_NOT_AGREED)
+        }
+
+        val termsToAgree = termRepository.findAllByIds(agreedTermIds)
+        val now = LocalDateTime.now()
+
+        val agreements = termsToAgree.map { term ->
+            UserTermAgreement(
+                userId = command.userId,
+                termId = term.id!!,
+                agreedAt = now,
+                termVersion = term.version,
+            )
+        }
+
+        userTermAgreementRepository.saveAll(agreements)
+    }
+}

--- a/src/main/kotlin/com/yapp2app/term/application/usecase/GetTermsUseCase.kt
+++ b/src/main/kotlin/com/yapp2app/term/application/usecase/GetTermsUseCase.kt
@@ -13,7 +13,6 @@ class GetTermsUseCase(private val termRepository: TermRepositoryPort) {
 
         return GetTermsResult(
             terms = activeTerms
-                .sortedBy { it.displayOrder }
                 .map { term ->
                     TermInfo(
                         id = term.id!!,

--- a/src/main/kotlin/com/yapp2app/term/application/usecase/GetTermsUseCase.kt
+++ b/src/main/kotlin/com/yapp2app/term/application/usecase/GetTermsUseCase.kt
@@ -20,7 +20,6 @@ class GetTermsUseCase(private val termRepository: TermRepositoryPort) {
                         termType = term.termType,
                         title = term.title,
                         url = term.url,
-                        version = term.version,
                         isRequired = term.isRequired,
                     )
                 },

--- a/src/main/kotlin/com/yapp2app/term/application/usecase/GetTermsUseCase.kt
+++ b/src/main/kotlin/com/yapp2app/term/application/usecase/GetTermsUseCase.kt
@@ -1,0 +1,29 @@
+package com.yapp2app.term.application.usecase
+
+import com.yapp2app.common.annotation.UseCase
+import com.yapp2app.term.application.port.TermRepositoryPort
+import com.yapp2app.term.application.result.GetTermsResult
+import com.yapp2app.term.application.result.TermInfo
+
+@UseCase
+class GetTermsUseCase(private val termRepository: TermRepositoryPort) {
+
+    fun execute(): GetTermsResult {
+        val activeTerms = termRepository.findAllActiveTerms()
+
+        return GetTermsResult(
+            terms = activeTerms
+                .sortedBy { it.displayOrder }
+                .map { term ->
+                    TermInfo(
+                        id = term.id!!,
+                        termType = term.termType,
+                        title = term.title,
+                        url = term.url,
+                        version = term.version,
+                        isRequired = term.isRequired,
+                    )
+                },
+        )
+    }
+}

--- a/src/main/kotlin/com/yapp2app/term/domain/entity/Term.kt
+++ b/src/main/kotlin/com/yapp2app/term/domain/entity/Term.kt
@@ -1,0 +1,42 @@
+package com.yapp2app.term.domain.entity
+
+import com.yapp2app.common.domain.BaseTimeEntity
+import com.yapp2app.term.domain.enums.TermType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "TB_TERM")
+class Term(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "term_type", nullable = false, length = 50)
+    @Enumerated(EnumType.STRING)
+    val termType: TermType,
+
+    @Column(name = "title", nullable = false, length = 100)
+    val title: String,
+
+    @Column(name = "url", nullable = false, length = 500)
+    val url: String,
+
+    @Column(name = "version", nullable = false, length = 20)
+    val version: String,
+
+    @Column(name = "is_required", nullable = false)
+    val isRequired: Boolean = true,
+
+    @Column(name = "is_active", nullable = false)
+    val isActive: Boolean = true,
+
+    @Column(name = "display_order", nullable = false)
+    val displayOrder: Int = 0,
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/yapp2app/term/domain/entity/UserTermAgreement.kt
+++ b/src/main/kotlin/com/yapp2app/term/domain/entity/UserTermAgreement.kt
@@ -1,0 +1,44 @@
+package com.yapp2app.term.domain.entity
+
+import com.yapp2app.common.domain.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.io.Serializable
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "TB_USER_TERM_AGREEMENT")
+class UserTermAgreement(
+    @EmbeddedId
+    val id: UserTermAgreementId,
+
+    @Column(name = "agreed_at", nullable = false)
+    val agreedAt: LocalDateTime,
+
+    @Column(name = "term_version", nullable = false, length = 20)
+    val termVersion: String,
+) : BaseTimeEntity() {
+    protected constructor() : this(
+        UserTermAgreementId(0L, 0L),
+        LocalDateTime.now(),
+        "",
+    )
+
+    constructor(userId: Long, termId: Long, agreedAt: LocalDateTime, termVersion: String) : this(
+        UserTermAgreementId(userId, termId),
+        agreedAt,
+        termVersion,
+    )
+}
+
+@Embeddable
+data class UserTermAgreementId(
+    @Column(name = "user_id")
+    val userId: Long,
+
+    @Column(name = "term_id")
+    val termId: Long,
+) : Serializable

--- a/src/main/kotlin/com/yapp2app/term/domain/enums/TermType.kt
+++ b/src/main/kotlin/com/yapp2app/term/domain/enums/TermType.kt
@@ -1,0 +1,7 @@
+package com.yapp2app.term.domain.enums
+
+enum class TermType(val description: String) {
+    SERVICE("서비스 이용약관"),
+    PRIVACY("개인정보 처리방침"),
+    LOCATION("위치정보 이용약관"),
+}

--- a/src/main/kotlin/com/yapp2app/term/infra/persist/TermRepositoryAdapter.kt
+++ b/src/main/kotlin/com/yapp2app/term/infra/persist/TermRepositoryAdapter.kt
@@ -1,0 +1,17 @@
+package com.yapp2app.term.infra.persist
+
+import com.yapp2app.term.application.port.TermRepositoryPort
+import com.yapp2app.term.domain.entity.Term
+import com.yapp2app.term.infra.persist.jpa.JpaTermRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class TermRepositoryAdapter(private val jpaRepository: JpaTermRepository) : TermRepositoryPort {
+
+    override fun findAllActiveTerms(): List<Term> = jpaRepository.findAllByIsActiveTrueOrderByDisplayOrderAsc()
+
+    override fun findById(id: Long): Term? = jpaRepository.findByIdOrNull(id)
+
+    override fun findAllByIds(ids: List<Long>): List<Term> = jpaRepository.findAllById(ids)
+}

--- a/src/main/kotlin/com/yapp2app/term/infra/persist/UserTermAgreementRepositoryAdapter.kt
+++ b/src/main/kotlin/com/yapp2app/term/infra/persist/UserTermAgreementRepositoryAdapter.kt
@@ -1,0 +1,16 @@
+package com.yapp2app.term.infra.persist
+
+import com.yapp2app.term.application.port.UserTermAgreementRepositoryPort
+import com.yapp2app.term.domain.entity.UserTermAgreement
+import com.yapp2app.term.infra.persist.jpa.JpaUserTermAgreementRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class UserTermAgreementRepositoryAdapter(private val jpaRepository: JpaUserTermAgreementRepository) :
+    UserTermAgreementRepositoryPort {
+
+    override fun findByUserId(userId: Long): List<UserTermAgreement> = jpaRepository.findAllByIdUserId(userId)
+
+    override fun saveAll(agreements: List<UserTermAgreement>): List<UserTermAgreement> =
+        jpaRepository.saveAll(agreements)
+}

--- a/src/main/kotlin/com/yapp2app/term/infra/persist/jpa/JpaTermRepository.kt
+++ b/src/main/kotlin/com/yapp2app/term/infra/persist/jpa/JpaTermRepository.kt
@@ -1,0 +1,9 @@
+package com.yapp2app.term.infra.persist.jpa
+
+import com.yapp2app.term.domain.entity.Term
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaTermRepository : JpaRepository<Term, Long> {
+
+    fun findAllByIsActiveTrueOrderByDisplayOrderAsc(): List<Term>
+}

--- a/src/main/kotlin/com/yapp2app/term/infra/persist/jpa/JpaUserTermAgreementRepository.kt
+++ b/src/main/kotlin/com/yapp2app/term/infra/persist/jpa/JpaUserTermAgreementRepository.kt
@@ -1,0 +1,10 @@
+package com.yapp2app.term.infra.persist.jpa
+
+import com.yapp2app.term.domain.entity.UserTermAgreement
+import com.yapp2app.term.domain.entity.UserTermAgreementId
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaUserTermAgreementRepository : JpaRepository<UserTermAgreement, UserTermAgreementId> {
+
+    fun findAllByIdUserId(userId: Long): List<UserTermAgreement>
+}

--- a/src/main/kotlin/com/yapp2app/user/api/converter/UserResultConverter.kt
+++ b/src/main/kotlin/com/yapp2app/user/api/converter/UserResultConverter.kt
@@ -25,6 +25,7 @@ class UserResultConverter(private val appProperties: AppProperties) {
         email = result.email,
         profileImageUrl = toImageUrl(result.objectKey),
         providerType = result.providerType,
+        agreeTerms = result.agreeTerms,
     )
 
     private fun toImageUrl(storageKey: String?): String =

--- a/src/main/kotlin/com/yapp2app/user/api/dto/GetUserResponse.kt
+++ b/src/main/kotlin/com/yapp2app/user/api/dto/GetUserResponse.kt
@@ -21,9 +21,12 @@ data class GetUserResponse(
     @field:Schema(description = "이메일", example = "yapp@neki.com")
     val email: String?,
 
-    @field:Schema(description = "이메일", example = "https://dev-yapp.suitestudy.com:4641/file/image/...")
+    @field:Schema(description = "프로필 이미지 URL", example = "https://dev-yapp.suitestudy.com:4641/file/image/...")
     val profileImageUrl: String?,
 
     @field:Schema(description = "로그인 타입", example = "KAKAO")
     val providerType: ProviderType,
+
+    @field:Schema(description = "최신 약관 동의 여부", example = "true")
+    val agreeTerms: Boolean,
 )

--- a/src/main/kotlin/com/yapp2app/user/application/port/TermClientPort.kt
+++ b/src/main/kotlin/com/yapp2app/user/application/port/TermClientPort.kt
@@ -1,0 +1,6 @@
+package com.yapp2app.user.application.port
+
+interface TermClientPort {
+
+    fun hasAgreedToLatestTerms(userId: Long): Boolean
+}

--- a/src/main/kotlin/com/yapp2app/user/application/result/GetUserResult.kt
+++ b/src/main/kotlin/com/yapp2app/user/application/result/GetUserResult.kt
@@ -14,4 +14,5 @@ data class GetUserResult(
     val email: String?,
     val objectKey: String?,
     val providerType: ProviderType,
+    val agreeTerms: Boolean,
 )

--- a/src/main/kotlin/com/yapp2app/user/application/usecase/GetUserInfoUseCase.kt
+++ b/src/main/kotlin/com/yapp2app/user/application/usecase/GetUserInfoUseCase.kt
@@ -5,6 +5,7 @@ import com.yapp2app.common.api.dto.ResultCode
 import com.yapp2app.common.exception.BusinessException
 import com.yapp2app.user.application.command.GetUserCommand
 import com.yapp2app.user.application.port.MediaClientPort
+import com.yapp2app.user.application.port.TermClientPort
 import com.yapp2app.user.application.port.UserRepositoryPort
 import com.yapp2app.user.application.result.GetUserResult
 import com.yapp2app.user.domain.entity.User
@@ -16,7 +17,11 @@ import com.yapp2app.user.domain.entity.User
  * description    :
  */
 @UseCase
-class GetUserInfoUseCase(private val userRepository: UserRepositoryPort, private val mediaClient: MediaClientPort) {
+class GetUserInfoUseCase(
+    private val userRepository: UserRepositoryPort,
+    private val mediaClient: MediaClientPort,
+    private val termClient: TermClientPort,
+) {
 
     fun execute(command: GetUserCommand): GetUserResult {
         val user: User = userRepository.findById(command.userId)
@@ -26,12 +31,15 @@ class GetUserInfoUseCase(private val userRepository: UserRepositoryPort, private
             mediaClient.getStorageKey(ownerId = user.id!!, mediaId = it)
         }
 
+        val hasAgreedToLatestTerms = termClient.hasAgreedToLatestTerms(user.id!!)
+
         return GetUserResult(
             userId = user.id!!,
             name = user.name!!,
             email = user.email,
             objectKey = storageKey,
             providerType = user.providerType,
+            agreeTerms = hasAgreedToLatestTerms,
         )
     }
 }

--- a/src/main/kotlin/com/yapp2app/user/infra/client/UserTermClient.kt
+++ b/src/main/kotlin/com/yapp2app/user/infra/client/UserTermClient.kt
@@ -1,0 +1,17 @@
+package com.yapp2app.user.infra.client
+
+import com.yapp2app.term.application.command.CheckLatestTermsAgreementCommand
+import com.yapp2app.term.application.usecase.CheckLatestTermsAgreementUseCase
+import com.yapp2app.user.application.port.TermClientPort
+import org.springframework.stereotype.Component
+
+@Component
+class UserTermClient(private val checkLatestTermsAgreementUseCase: CheckLatestTermsAgreementUseCase) : TermClientPort {
+
+    override fun hasAgreedToLatestTerms(userId: Long): Boolean {
+        val result = checkLatestTermsAgreementUseCase.execute(
+            CheckLatestTermsAgreementCommand(userId = userId),
+        )
+        return result.hasAgreedToLatestTerms
+    }
+}

--- a/src/main/resources/db/migration/V7__create_term_tables.sql
+++ b/src/main/resources/db/migration/V7__create_term_tables.sql
@@ -1,0 +1,56 @@
+-- Create term table
+CREATE TABLE TB_TERM
+(
+    id            BIGSERIAL PRIMARY KEY,
+    term_type     VARCHAR(50)  NOT NULL,
+    title         VARCHAR(100) NOT NULL,
+    url           VARCHAR(500) NOT NULL,
+    version       VARCHAR(20)  NOT NULL,
+    is_required   BOOLEAN      NOT NULL DEFAULT true,
+    is_active     BOOLEAN      NOT NULL DEFAULT true,
+    display_order INT          NOT NULL DEFAULT 0,
+    created_at    TIMESTAMP    NOT NULL,
+    updated_at    TIMESTAMP    NOT NULL
+);
+
+-- Add comments for term table
+COMMENT ON TABLE TB_TERM IS '약관 정보 테이블';
+COMMENT ON COLUMN TB_TERM.id IS '약관 고유 ID';
+COMMENT ON COLUMN TB_TERM.term_type IS '약관 종류 (SERVICE, PRIVACY, LOCATION)';
+COMMENT ON COLUMN TB_TERM.title IS '약관 제목';
+COMMENT ON COLUMN TB_TERM.url IS '약관 상세 페이지 URL';
+COMMENT ON COLUMN TB_TERM.version IS '약관 버전';
+COMMENT ON COLUMN TB_TERM.is_required IS '필수 동의 여부';
+COMMENT ON COLUMN TB_TERM.is_active IS '현재 활성 버전 여부';
+COMMENT ON COLUMN TB_TERM.display_order IS '표시 순서';
+COMMENT ON COLUMN TB_TERM.created_at IS '생성일시';
+COMMENT ON COLUMN TB_TERM.updated_at IS '수정일시';
+
+-- Insert initial term data
+INSERT INTO TB_TERM (term_type, title, url, version, is_required, is_active, display_order, created_at, updated_at)
+VALUES
+    ('SERVICE', '서비스 이용약관', 'https://lydian-tip-26b.notion.site/2ee0d9441db0807c8684ce3e2d4b8aca', '1.0.0', true, true, 1, NOW(), NOW()),
+    ('PRIVACY', '개인정보 수집 및 이용동의', 'https://lydian-tip-26b.notion.site/2ee0d9441db0807cb850f78145db6dd3', '1.0.0', true, true, 2, NOW(), NOW()),
+    ('LOCATION', '위치정보 수집 및 이용 동의', 'https://lydian-tip-26b.notion.site/2ee0d9441db080b48223fb0b3263da08', '1.0.0', true, true, 3, NOW(), NOW());
+
+-- Create user_term_agreement table
+CREATE TABLE TB_USER_TERM_AGREEMENT
+(
+    user_id      BIGINT      NOT NULL,
+    term_id      BIGINT      NOT NULL,
+    agreed_at    TIMESTAMP   NOT NULL,
+    term_version VARCHAR(20) NOT NULL,
+    created_at   TIMESTAMP   NOT NULL,
+    updated_at   TIMESTAMP   NOT NULL,
+
+    PRIMARY KEY (user_id, term_id)
+);
+
+-- Add comments for user_term_agreement table
+COMMENT ON TABLE TB_USER_TERM_AGREEMENT IS '사용자 약관 동의 기록 테이블';
+COMMENT ON COLUMN TB_USER_TERM_AGREEMENT.user_id IS '사용자 ID';
+COMMENT ON COLUMN TB_USER_TERM_AGREEMENT.term_id IS '약관 ID';
+COMMENT ON COLUMN TB_USER_TERM_AGREEMENT.agreed_at IS '동의 일시';
+COMMENT ON COLUMN TB_USER_TERM_AGREEMENT.term_version IS '동의한 약관 버전';
+COMMENT ON COLUMN TB_USER_TERM_AGREEMENT.created_at IS '생성일시';
+COMMENT ON COLUMN TB_USER_TERM_AGREEMENT.updated_at IS '수정일시';


### PR DESCRIPTION
## Description
- 약관 관리 기능 구현 (Term 도메인 신규 생성)
- 활성 약관 목록 조회 API 추가 (`GET /api/terms`)
- 약관 동의 API 추가 (`POST /api/terms/agreements`)
- 내 정보 조회 시 최신 약관 동의 여부 반환 (`agreeTerms` 필드 추가)

### 기존 도메인 수정: User
- `GET /api/users/info` 응답에 `agreeTerms: Boolean` 필드 추가
- 사용자가 최신 버전의 모든 약관에 동의했는지 여부 반환
                                                                                                                                                                                                                                                     
### DB 마이그레이션 (V7)
- `TB_TERM`: 약관 정보 테이블
- `TB_USER_TERM_AGREEMENT`: 사용자별 약관 동의 기록 테이블
- 초기 약관 데이터 3건 (서비스 이용약관, 개인정보 수집 및 이용동의, 위치정보 수집 및 이용 동의)