### PR TITLE
fix: photo 업로드 멱등성

### DIFF
--- a/src/main/kotlin/com/yapp2app/photo/application/port/PhotoImageRepositoryPort.kt
+++ b/src/main/kotlin/com/yapp2app/photo/application/port/PhotoImageRepositoryPort.kt
@@ -19,6 +19,8 @@ interface PhotoImageRepositoryPort {
 
     fun saveAll(photoImages: List<PhotoImage>): List<PhotoImage>
 
+    fun getRegisteredMediaIds(mediaIds: List<Long>): Set<Long>
+
     /**
      * 조회
      */

--- a/src/main/kotlin/com/yapp2app/photo/application/usecase/UploadPhotosUseCase.kt
+++ b/src/main/kotlin/com/yapp2app/photo/application/usecase/UploadPhotosUseCase.kt
@@ -12,7 +12,7 @@ import com.yapp2app.photo.application.port.PhotoImageRepositoryPort
 import com.yapp2app.photo.domain.entity.PhotoImage
 
 /**
- * fileName       : BulkUploadPhotoUseCase
+ * fileName       : UploadPhotosUseCase
  * author         : koo
  * date           : 2026. 1. 20.
  * description    : 다중 사진 업로드 UseCase (최대 10장)
@@ -30,17 +30,18 @@ class UploadPhotosUseCase(
         validateNoDuplicateMediaIds(command.uploads)
         validateFolderOwnership(command.userId, command.folderId)
 
-        val mediaIds = command.uploads.map { it.mediaId }
+        val newUploads = filterNewUploads(command.uploads)
+        if (newUploads.isEmpty()) return
 
-        // 모든 media가 object storage에 정상적으로 저장되었는지 일괄 확인
+        val newMediaIds = newUploads.map { it.mediaId }
+
         val availabilities = mediaClient.verifyMediasUploaded(
             ownerId = command.userId,
-            mediaIds = mediaIds,
+            mediaIds = newMediaIds,
         )
-
         rollbackIfFailed(command.userId, availabilities)
 
-        val photos = command.uploads.map { upload ->
+        val photos = newUploads.map { upload ->
             PhotoImage(
                 userId = command.userId,
                 mediaId = upload.mediaId,
@@ -53,11 +54,20 @@ class UploadPhotosUseCase(
             transactionRunner.run {
                 photoImageRepository.saveAll(photos)
             }
+        } catch (e: BusinessException) {
+            if (e.resultCode == ResultCode.ALREADY_REQUEST) return
+            mediaClient.rollbackMediasUploaded(command.userId, newMediaIds)
+            throw e
         } catch (e: Exception) {
-            // 보상 트랜잭션: 모든 media 상태를 INITIATED로 롤백
-            mediaClient.rollbackMediasUploaded(command.userId, mediaIds)
+            mediaClient.rollbackMediasUploaded(command.userId, newMediaIds)
             throw e
         }
+    }
+
+    private fun filterNewUploads(uploads: List<UploadPhotoCommand.UploadItem>): List<UploadPhotoCommand.UploadItem> {
+        val mediaIds = uploads.map { it.mediaId }
+        val existingMediaIds = photoImageRepository.getRegisteredMediaIds(mediaIds)
+        return uploads.filter { it.mediaId !in existingMediaIds }
     }
 
     private fun validateNoDuplicateMediaIds(uploads: List<UploadPhotoCommand.UploadItem>) {

--- a/src/main/kotlin/com/yapp2app/photo/infra/persist/PhotoImageRepositoryAdapter.kt
+++ b/src/main/kotlin/com/yapp2app/photo/infra/persist/PhotoImageRepositoryAdapter.kt
@@ -1,11 +1,14 @@
 package com.yapp2app.photo.infra.persist
 
+import com.yapp2app.common.api.dto.ResultCode
 import com.yapp2app.common.domain.vo.SortOrder
+import com.yapp2app.common.exception.BusinessException
 import com.yapp2app.photo.application.contract.PhotoWithFavorite
 import com.yapp2app.photo.application.port.PhotoImageRepositoryPort
 import com.yapp2app.photo.domain.entity.PhotoImage
 import com.yapp2app.photo.infra.persist.jpa.JpaPhotoImageRepository
 import com.yapp2app.photo.infra.persist.jpa.PhotoImageQueryRepository
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Repository
 
 /**
@@ -24,7 +27,14 @@ class PhotoImageRepositoryAdapter(
         queryRepository.findOwnedPhotoWithFavorite(userId, photoId)
 
     override fun save(photoImage: PhotoImage): PhotoImage = jpaRepository.save(photoImage)
-    override fun saveAll(photoImages: List<PhotoImage>): List<PhotoImage> = jpaRepository.saveAll(photoImages)
+    override fun saveAll(photoImages: List<PhotoImage>): List<PhotoImage> = try {
+        jpaRepository.saveAll(photoImages)
+    } catch (e: DataIntegrityViolationException) {
+        throw BusinessException(ResultCode.ALREADY_REQUEST)
+    }
+
+    override fun getRegisteredMediaIds(mediaIds: List<Long>): Set<Long> =
+        queryRepository.getRegisteredMediaIds(mediaIds)
 
     override fun listOwnedPhotos(userId: Long, offset: Int, limit: Int, sortOrder: SortOrder): List<PhotoImage> =
         queryRepository.findOwnedPhotos(userId, offset, limit, sortOrder)

--- a/src/main/kotlin/com/yapp2app/photo/infra/persist/jpa/PhotoImageQueryRepository.kt
+++ b/src/main/kotlin/com/yapp2app/photo/infra/persist/jpa/PhotoImageQueryRepository.kt
@@ -148,6 +148,17 @@ class PhotoImageQueryRepository(private val queryFactory: JPAQueryFactory) {
             .fetch()
     }
 
+    fun getRegisteredMediaIds(mediaIds: List<Long>): Set<Long> {
+        if (mediaIds.isEmpty()) return emptySet()
+
+        return queryFactory
+            .select(photoImage.mediaId)
+            .from(photoImage)
+            .where(photoImage.mediaId.`in`(mediaIds))
+            .fetch()
+            .toSet()
+    }
+
     fun removePhotosFromFolder(userId: Long, folderId: Long, photoIds: List<Long>): Int {
         if (photoIds.isEmpty()) return 0
 

--- a/src/main/resources/db/migration/V10__add_unique_constraint_media_id_to_photo_image.sql
+++ b/src/main/resources/db/migration/V10__add_unique_constraint_media_id_to_photo_image.sql
@@ -1,0 +1,2 @@
+ALTER TABLE TB_PHOTO_IMAGE
+    ADD CONSTRAINT uk_photo_image_media_id UNIQUE (media_id);

--- a/src/test/kotlin/com/yapp2app/e2e/photo/image/UploadPhotosIdempotencyE2ETest.kt
+++ b/src/test/kotlin/com/yapp2app/e2e/photo/image/UploadPhotosIdempotencyE2ETest.kt
@@ -1,0 +1,196 @@
+package com.yapp2app.e2e.photo.image
+
+import com.yapp2app.common.api.dto.ResultCode
+import com.yapp2app.media.api.dto.UploadTicketRequest
+import com.yapp2app.media.domain.MediaType
+import com.yapp2app.photo.api.dto.UploadPhotoRequest
+import com.yapp2app.photo.infra.persist.jpa.PhotoImageQueryRepository
+import com.yapp2app.user.domain.entity.User
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+
+/**
+ * fileName       : UploadPhotosIdempotencyE2ETest
+ * author         : claude
+ * date           : 2026. 2. 14.
+ * description    : POST /api/photos 멱등성 보장 E2E 테스트
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class UploadPhotosIdempotencyE2ETest : PhotoImageE2ETestBase() {
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    @Autowired
+    private lateinit var photoImageQueryRepository: PhotoImageQueryRepository
+
+    private lateinit var accessToken: String
+    private lateinit var testUser: User
+
+    @BeforeEach
+    fun setUp() {
+        RestAssured.port = port
+        RestAssured.baseURI = "http://localhost"
+
+        val (user, token) = createTestUserAndToken()
+        testUser = user
+        accessToken = token
+    }
+
+    // ===================
+    // Helper Methods
+    // ===================
+
+    private fun createMediaIds(count: Int): List<Long> {
+        val ticketRequest = UploadTicketRequest(
+            items = (1..count).map {
+                UploadTicketRequest.UploadTicketItem(
+                    filename = "photo$it.jpg",
+                    contentType = "image/jpeg",
+                    mediaType = MediaType.PHOTO_BOOTH,
+                )
+            },
+        )
+
+        return RestAssured.given()
+            .contentType(ContentType.JSON)
+            .header("Authorization", "Bearer $accessToken")
+            .body(ticketRequest)
+            .`when`()
+            .post("/api/media/upload")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract()
+            .jsonPath()
+            .getList<Int>("data.items.mediaId")
+            .map { it.toLong() }
+    }
+
+    private fun uploadPhotos(folderId: Long?, mediaIds: List<Long>) {
+        val uploadRequest = UploadPhotoRequest(
+            folderId = folderId,
+            uploads = mediaIds.map {
+                UploadPhotoRequest.UploadPhotoItem(
+                    mediaId = it,
+                    memo = null,
+                )
+            },
+        )
+
+        RestAssured.given()
+            .contentType(ContentType.JSON)
+            .header("Authorization", "Bearer $accessToken")
+            .body(uploadRequest)
+            .`when`()
+            .post("/api/photos")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("resultCode", equalTo(ResultCode.SUCCESS.code))
+    }
+
+    // ===================
+    // Test Cases
+    // ===================
+
+    @Test
+    @DisplayName("동일 mediaIds로 두 번 호출해도 두 번째 호출이 성공하고 레코드가 중복 생성되지 않는다")
+    fun givenAlreadyUploadedPhotos_whenRetryWithSameMediaIds_thenIdempotentSuccess() {
+        // given
+        val mediaIds = createMediaIds(3)
+
+        // 첫 번째 호출 → 정상 저장
+        uploadPhotos(null, mediaIds)
+        val countAfterFirst = photoImageQueryRepository.getRegisteredMediaIds(mediaIds).size
+
+        // when: 동일 mediaIds로 두 번째 호출
+        uploadPhotos(null, mediaIds)
+        val countAfterSecond = photoImageQueryRepository.getRegisteredMediaIds(mediaIds).size
+
+        // then: 레코드 수가 변하지 않아야 함
+        assertThat(countAfterFirst).isEqualTo(3)
+        assertThat(countAfterSecond).isEqualTo(3)
+    }
+
+    @Test
+    @DisplayName("폴더 지정 후 동일 mediaIds로 재시도해도 멱등 성공")
+    fun givenPhotosInFolder_whenRetryWithSameMediaIds_thenIdempotentSuccess() {
+        // given
+        val folder = createFolder(testUser.id!!, "테스트 폴더")
+        val mediaIds = createMediaIds(2)
+
+        // 첫 번째 호출
+        uploadPhotos(folder.id, mediaIds)
+
+        // when: 동일 요청 재시도
+        uploadPhotos(folder.id, mediaIds)
+
+        // then
+        assertThat(photoImageQueryRepository.getRegisteredMediaIds(mediaIds)).hasSize(2)
+
+        RestAssured.given()
+            .header("Authorization", "Bearer $accessToken")
+            .queryParam("folderId", folder.id)
+            .`when`()
+            .get("/api/photos")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.items.size()", equalTo(2))
+    }
+
+    @Test
+    @DisplayName("부분적으로 저장된 상태에서 전체 mediaIds로 재시도하면 나머지만 저장된다")
+    fun givenPartialUpload_whenRetryWithAllMediaIds_thenOnlyNewOnesAreSaved() {
+        // given: mediaId 3개 발급 후 앞 2개만 먼저 업로드
+        val mediaIds = createMediaIds(3)
+        uploadPhotos(null, mediaIds.take(2))
+
+        val countAfterPartial = photoImageQueryRepository.getRegisteredMediaIds(mediaIds).size
+        assertThat(countAfterPartial).isEqualTo(2)
+
+        // when: 3개 전부로 재시도
+        uploadPhotos(null, mediaIds)
+
+        // then: 3개 레코드가 존재해야 함
+        assertThat(photoImageQueryRepository.getRegisteredMediaIds(mediaIds)).hasSize(3)
+    }
+
+    @Test
+    @DisplayName("단건 업로드 후 동일 mediaId로 재시도해도 멱등 성공")
+    fun givenSinglePhoto_whenRetryUpload_thenIdempotentSuccess() {
+        // given
+        val mediaIds = createMediaIds(1)
+        uploadPhotos(null, mediaIds)
+
+        // when
+        uploadPhotos(null, mediaIds)
+
+        // then
+        assertThat(photoImageQueryRepository.getRegisteredMediaIds(mediaIds)).hasSize(1)
+    }
+
+    @Test
+    @DisplayName("최초 업로드는 정상적으로 저장된다")
+    fun givenNewMediaIds_whenUpload_thenAllSaved() {
+        // given
+        val mediaIds = createMediaIds(3)
+
+        // when
+        uploadPhotos(null, mediaIds)
+
+        // then
+        val registeredMediaIds = photoImageQueryRepository.getRegisteredMediaIds(mediaIds)
+        assertThat(registeredMediaIds).hasSize(3)
+        assertThat(registeredMediaIds).isEqualTo(mediaIds.toSet())
+    }
+}


### PR DESCRIPTION
## summary
- photo image 생성 API 멱등성 보장 로직 추가

## details
PhotoImage 테이블의 mediaId에 대한 unique key 제약 조건을 걸어 중복 요청에 대해 중복 처리가 되지 않도록 수정하였습니다. PhotoImage의 각 항목은 하나의 mediaId와 1:1 대응이 되기 때문에 별도의 멱등성 처리를 위한 테이블이나 락 등을 사용하지 않았습니다.

로직 추가에 따른 flyway schema 갱신, e2e test를 포함하였습니다.

c.c. PR에서 멱등성과 관련된 로직을 우선 검토하여 쿼리가 불필요하게 나가는 부분들이 있는데 이 부분은 테스트하면서 점차 개선해나갈 예정입니다. 혹시 추가 의견주시면 반영하겠습니다.