### PR TITLE
fix: 사진 등록 즐겨찾기 필드 추가

### DIFF
--- a/src/main/kotlin/com/yapp2app/photo/api/converter/PhotoImageCommandConverter.kt
+++ b/src/main/kotlin/com/yapp2app/photo/api/converter/PhotoImageCommandConverter.kt
@@ -29,6 +29,7 @@ class PhotoImageCommandConverter {
                 memo = item.memo,
             )
         },
+        favorite = request.favorite ?: false,
     )
 
     fun toGetPhotosCommand(

--- a/src/main/kotlin/com/yapp2app/photo/api/dto/PhotoImageRequest.kt
+++ b/src/main/kotlin/com/yapp2app/photo/api/dto/PhotoImageRequest.kt
@@ -5,6 +5,7 @@ import jakarta.annotation.Nullable
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
 
 /**
  * fileName       : PhotoImageRequest
@@ -18,8 +19,11 @@ data class UploadPhotoRequest(
 
     @field:NotEmpty(message = "uploads가 비어있습니다.")
     @field:Valid
-    @field:jakarta.validation.constraints.Size(max = 10, message = "한 번에 최대 10장까지 업로드할 수 있습니다.")
+    @field:Size(max = 10, message = "한 번에 최대 10장까지 업로드할 수 있습니다.")
     val uploads: List<UploadPhotoItem>,
+
+    @field:Schema(description = "업로드 사진 즐겨찾기 등록 여부", example = "true")
+    val favorite: Boolean? = null,
 ) {
     data class UploadPhotoItem(
         @field:NotNull(message = "mediaId는 필수 입력값입니다.")

--- a/src/main/kotlin/com/yapp2app/photo/application/command/PhotoImageCommand.kt
+++ b/src/main/kotlin/com/yapp2app/photo/application/command/PhotoImageCommand.kt
@@ -8,7 +8,12 @@ import com.yapp2app.common.domain.vo.SortOrder
  * date           : 2026. 1. 2. 오후 8:28
  * description    : Photo image domain command
  */
-data class UploadPhotoCommand(val userId: Long, val folderId: Long?, val uploads: List<UploadItem>) {
+data class UploadPhotoCommand(
+    val userId: Long,
+    val folderId: Long?,
+    val uploads: List<UploadItem>,
+    val favorite: Boolean,
+) {
     data class UploadItem(val mediaId: Long, val memo: String?)
 }
 

--- a/src/main/kotlin/com/yapp2app/photo/application/port/FavoriteImageRepositoryPort.kt
+++ b/src/main/kotlin/com/yapp2app/photo/application/port/FavoriteImageRepositoryPort.kt
@@ -10,6 +10,8 @@ interface FavoriteImageRepositoryPort {
 
     fun add(userId: Long, photoId: Long)
 
+    fun addAll(userId: Long, photoIds: List<Long>)
+
     fun delete(userId: Long, photoId: Long)
 
     fun deleteAll(userId: Long, photoIds: List<Long>)

--- a/src/main/kotlin/com/yapp2app/photo/application/usecase/UploadPhotosUseCase.kt
+++ b/src/main/kotlin/com/yapp2app/photo/application/usecase/UploadPhotosUseCase.kt
@@ -6,6 +6,7 @@ import com.yapp2app.common.exception.BusinessException
 import com.yapp2app.common.transaction.TransactionRunner
 import com.yapp2app.photo.application.command.UploadPhotoCommand
 import com.yapp2app.photo.application.contract.MediaAvailability
+import com.yapp2app.photo.application.port.FavoriteImageRepositoryPort
 import com.yapp2app.photo.application.port.FolderRepositoryPort
 import com.yapp2app.photo.application.port.MediaClientPort
 import com.yapp2app.photo.application.port.PhotoImageRepositoryPort
@@ -22,6 +23,7 @@ class UploadPhotosUseCase(
     private val mediaClient: MediaClientPort,
     private val photoImageRepository: PhotoImageRepositoryPort,
     private val folderRepository: FolderRepositoryPort,
+    private val favoriteImageRepository: FavoriteImageRepositoryPort,
 
     private val transactionRunner: TransactionRunner,
 ) {
@@ -52,7 +54,10 @@ class UploadPhotosUseCase(
 
         try {
             transactionRunner.run {
-                photoImageRepository.saveAll(photos)
+                val savedPhotos = photoImageRepository.saveAll(photos)
+                if (command.favorite) {
+                    favoriteImageRepository.addAll(command.userId, savedPhotos.map { it.id!! })
+                }
             }
         } catch (e: BusinessException) {
             if (e.resultCode == ResultCode.ALREADY_REQUEST) return

--- a/src/main/kotlin/com/yapp2app/photo/infra/persist/FavoriteImageRepositoryAdapter.kt
+++ b/src/main/kotlin/com/yapp2app/photo/infra/persist/FavoriteImageRepositoryAdapter.kt
@@ -27,6 +27,12 @@ class FavoriteImageRepositoryAdapter(
         }
     }
 
+    override fun addAll(userId: Long, photoIds: List<Long>) {
+        if (photoIds.isEmpty()) return
+        val favorites = photoIds.map { photoId -> FavoritePhoto(FavoritePhotoId(userId, photoId)) }
+        jpaRepository.saveAll(favorites)
+    }
+
     override fun delete(userId: Long, photoId: Long) = jpaRepository.deleteById(
         FavoritePhotoId(userId, photoId),
     )


### PR DESCRIPTION
closes: #139 

## summary
- 즐겨찾기 폴더에서 바로 사진을 등록하기 위해 사진 등록 API에 즐겨찾기 여부 추가

## details
- 즐겨찾기가 true인 경우에만 추가로 데이터를 insert하도록 addAll 로직 추가
- 기존 API 호환성을 위해 favorite에 null 허용