### PR TITLE
Chore/#147: 계층간 의존성 규칙 추가

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && ./gradlew spotlessApply",
+            "timeout": 120
+          },
+          {
+            "type": "command",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && ./gradlew test",
+            "timeout": 300
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ val kotestVersion = "5.9.1"
 val kotestExtensionsVersion = "1.3.0"
 val mockkVersion = "1.13.10"
 val ktlintVersion = "1.5.0"
+val archunitVersion = "1.3.0"
 
 group = "com.neki"
 version = "1.0.0"
@@ -111,6 +112,7 @@ dependencies {
     testImplementation("io.mockk:mockk:$mockkVersion")
     testRuntimeOnly("com.h2database:h2")
     testImplementation("io.rest-assured:rest-assured")
+    testImplementation("com.tngtech.archunit:archunit-junit5:$archunitVersion")
 }
 
 spotless {

--- a/src/main/kotlin/com/neki/auth/application/contract/KakaoClientPayload.kt
+++ b/src/main/kotlin/com/neki/auth/application/contract/KakaoClientPayload.kt
@@ -5,7 +5,7 @@ import com.neki.user.domain.enums.ProviderType
 /**
  * 카카오 사용자정보 추출 DTO
  */
-data class OauthInfoResponse(
+data class OauthInfoPayload(
     val providerType: ProviderType,
     val oid: String,
     val email: String?,
@@ -13,7 +13,7 @@ data class OauthInfoResponse(
     val imageUrl: String?,
 )
 
-data class OIDCDecodePayloadResponse(
+data class OIDCDecodePayload(
     /** issuer ex https://kauth.kakao.com  */
     val iss: String,
     /** client id  */
@@ -28,7 +28,7 @@ data class OIDCDecodePayloadResponse(
     val imageUrl: String?,
 )
 
-data class OIDCPublicKeysResponse(val keys: MutableList<OIDCPublicKeyDto>)
+data class OIDCPublicKeysPayload(val keys: MutableList<OIDCPublicKeyDto>)
 
 data class OIDCPublicKeyDto(val kid: String, val alg: String, val use: String, val n: String, val e: String)
 
@@ -38,7 +38,7 @@ data class OIDCPublicKeyDto(val kid: String, val alg: String, val use: String, v
  * date           : 2025. 12. 26. 18:20
  * description    : Auth usercase 관련 result idToken을 얻기 위한 테스트 DTO
  */
-data class GetKakaoTokenResponse(
+data class KakaoTokenPayload(
     val accessToken: String,
     val tokenType: String,
     val refreshToken: String,

--- a/src/main/kotlin/com/neki/auth/application/port/AuthCachePort.kt
+++ b/src/main/kotlin/com/neki/auth/application/port/AuthCachePort.kt
@@ -1,6 +1,6 @@
 package com.neki.auth.application.port
 
-import com.neki.auth.application.contract.OIDCPublicKeysResponse
+import com.neki.auth.application.contract.OIDCPublicKeysPayload
 import java.time.Duration
 
 /**
@@ -10,9 +10,9 @@ import java.time.Duration
  * description    : 캐시사용을 위한 Port 인터페이스
  */
 interface AuthCachePort {
-    fun setPublicKeys(key: String, value: OIDCPublicKeysResponse, ttl: Duration)
+    fun setPublicKeys(key: String, value: OIDCPublicKeysPayload, ttl: Duration)
 
-    fun getPublicKeys(key: String): OIDCPublicKeysResponse?
+    fun getPublicKeys(key: String): OIDCPublicKeysPayload?
 
     fun clearPublicKeys(key: String)
 }

--- a/src/main/kotlin/com/neki/auth/application/port/OidcTokenValidatorPort.kt
+++ b/src/main/kotlin/com/neki/auth/application/port/OidcTokenValidatorPort.kt
@@ -1,6 +1,6 @@
 package com.neki.auth.application.port
 
-import com.neki.auth.application.contract.OauthInfoResponse
+import com.neki.auth.application.contract.OauthInfoPayload
 import com.neki.auth.domain.Platform
 import com.neki.user.domain.enums.ProviderType
 
@@ -11,5 +11,5 @@ import com.neki.user.domain.enums.ProviderType
  * description    :
  */
 interface OidcTokenValidatorPort {
-    fun validateIdToken(idToken: String, providerType: ProviderType, platform: Platform): OauthInfoResponse
+    fun validateIdToken(idToken: String, providerType: ProviderType, platform: Platform): OauthInfoPayload
 }

--- a/src/main/kotlin/com/neki/auth/application/usecase/OauthLoginUseCase.kt
+++ b/src/main/kotlin/com/neki/auth/application/usecase/OauthLoginUseCase.kt
@@ -2,8 +2,8 @@ package com.neki.auth.application.usecase
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.neki.auth.application.command.RegisterOauthUserCommand
-import com.neki.auth.application.contract.GetKakaoTokenResponse
-import com.neki.auth.application.contract.OauthInfoResponse
+import com.neki.auth.application.contract.KakaoTokenPayload
+import com.neki.auth.application.contract.OauthInfoPayload
 import com.neki.auth.application.port.AuthTokenProviderPort
 import com.neki.auth.application.port.NicknameGeneratorPort
 import com.neki.auth.application.port.OidcTokenValidatorPort
@@ -45,14 +45,14 @@ class OauthLoginUseCase(
      * 4. oauthInfoResult 값 여부에 따라 회원가입 처리
      */
     fun execute(command: RegisterOauthUserCommand): GetAuthResult {
-        val oauthInfoResponse = oidcTokenValidatorPort.validateIdToken(
+        val oauthInfoPayload = oidcTokenValidatorPort.validateIdToken(
             command.idToken,
             command.providerType,
             command.platform,
         )
 
         // 신규 사용자 추가
-        val (user, _) = transactionRunner.run { registerOauthUserIfEmpty(oauthInfoResponse) }
+        val (user, _) = transactionRunner.run { registerOauthUserIfEmpty(oauthInfoPayload) }
 
         // 토큰 생성
         val accessToken = tokenProviderPort.createAccessToken(
@@ -75,10 +75,10 @@ class OauthLoginUseCase(
         )
     }
 
-    private fun registerOauthUserIfEmpty(oauthInfoResponse: OauthInfoResponse): Pair<User, Boolean> {
+    private fun registerOauthUserIfEmpty(oauthInfoPayload: OauthInfoPayload): Pair<User, Boolean> {
         val existingUser = userRepositoryPort.findByOid(
-            oid = oauthInfoResponse.oid,
-            provider = oauthInfoResponse.providerType,
+            oid = oauthInfoPayload.oid,
+            provider = oauthInfoPayload.providerType,
         )
 
         return if (existingUser != null) {
@@ -87,11 +87,11 @@ class OauthLoginUseCase(
             val nickname = nicknameGenerator.generateUniqueNickname()
             val newUser = userRepositoryPort.save(
                 User(
-                    email = oauthInfoResponse.email,
-                    oid = oauthInfoResponse.oid,
+                    email = oauthInfoPayload.email,
+                    oid = oauthInfoPayload.oid,
                     name = nickname,
                     roles = RoleType.USER.role,
-                    providerType = oauthInfoResponse.providerType,
+                    providerType = oauthInfoPayload.providerType,
                     profileImageId = null,
                 ),
             )
@@ -108,7 +108,7 @@ class OauthLoginUseCase(
      * @return KakaoTokenResponse 카카오 토큰 정보
      * @throws Exception 토큰 획득 실패 시
      */
-    fun getAccessTokenByCode(code: String): GetKakaoTokenResponse {
+    fun getAccessTokenByCode(code: String): KakaoTokenPayload {
         val clientId = oauthProperties.kakao.androidClientId
         val clientSecret = oauthProperties.kakao.clientSecret
 
@@ -133,7 +133,7 @@ class OauthLoginUseCase(
         val objectMapper = jacksonObjectMapper()
         val jsonNode = objectMapper.readTree(response)
 
-        return GetKakaoTokenResponse(
+        return KakaoTokenPayload(
             accessToken = jsonNode.get("access_token").asText(),
             tokenType = jsonNode.get("token_type").asText(),
             refreshToken = jsonNode.get("refresh_token").asText(),

--- a/src/main/kotlin/com/neki/auth/infra/oauth/OidcTokenValidator.kt
+++ b/src/main/kotlin/com/neki/auth/infra/oauth/OidcTokenValidator.kt
@@ -1,7 +1,7 @@
 package com.neki.auth.infra.oauth
 
 import com.neki.auth.application.contract.AuthCacheKeys
-import com.neki.auth.application.contract.OauthInfoResponse
+import com.neki.auth.application.contract.OauthInfoPayload
 import com.neki.auth.application.port.OidcTokenValidatorPort
 import com.neki.auth.domain.Platform
 import com.neki.auth.infra.oauth.helper.OauthHelper
@@ -34,7 +34,7 @@ class OidcTokenValidator(
      * - 1차 시도: 캐시된 공개키로 토큰 검증
      * - BusinessException 발생 시: 캐시 무효화 후 재시도 (공개키 로테이션 대응)
      */
-    override fun validateIdToken(idToken: String, providerType: ProviderType, platform: Platform): OauthInfoResponse {
+    override fun validateIdToken(idToken: String, providerType: ProviderType, platform: Platform): OauthInfoPayload {
         val oidcAdapter = oidcRegistry.getAdapter(providerType)
         val oauthHelperAdapter = oauthHelperRegistry.getAdapter(providerType)
 
@@ -60,7 +60,7 @@ class OidcTokenValidator(
         oidc: Oidc,
         oauthHelper: OauthHelper,
         platform: Platform,
-    ): OauthInfoResponse {
+    ): OauthInfoPayload {
         val publicKeys = oidc.getOIDCPublicKey()
         return oauthHelper.getOauthInfoByIdToken(
             idToken = idToken,

--- a/src/main/kotlin/com/neki/auth/infra/oauth/helper/AppleOauthHelper.kt
+++ b/src/main/kotlin/com/neki/auth/infra/oauth/helper/AppleOauthHelper.kt
@@ -1,10 +1,10 @@
 package com.neki.auth.infra.oauth.helper
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.neki.auth.application.contract.OIDCDecodePayloadResponse
+import com.neki.auth.application.contract.OIDCDecodePayload
 import com.neki.auth.application.contract.OIDCPublicKeyDto
-import com.neki.auth.application.contract.OIDCPublicKeysResponse
-import com.neki.auth.application.contract.OauthInfoResponse
+import com.neki.auth.application.contract.OIDCPublicKeysPayload
+import com.neki.auth.application.contract.OauthInfoPayload
 import com.neki.auth.domain.Platform
 import com.neki.auth.infra.security.properties.OauthProperties
 import com.neki.common.api.dto.ResultCode
@@ -61,9 +61,9 @@ class AppleOauthHelper(private val oauthProperties: OauthProperties, private val
      */
     override fun getOauthInfoByIdToken(
         idToken: String,
-        publicKeys: OIDCPublicKeysResponse,
+        publicKeys: OIDCPublicKeysPayload,
         platform: Platform,
-    ): OauthInfoResponse {
+    ): OauthInfoPayload {
         // Step 1: 헤더에서 kid 추출
         val kid = extractKidFromTokenHeader(idToken)
 
@@ -79,7 +79,7 @@ class AppleOauthHelper(private val oauthProperties: OauthProperties, private val
             expectedAudience = oauthProperties.apple.clientId,
         )
 
-        return OauthInfoResponse(
+        return OauthInfoPayload(
             providerType = ProviderType.APPLE,
             oid = payload.sub, // String 그대로 사용 (UUID)
             email = payload.email,
@@ -122,11 +122,11 @@ class AppleOauthHelper(private val oauthProperties: OauthProperties, private val
         publicKey: OIDCPublicKeyDto,
         expectedIssuer: String,
         expectedAudience: String,
-    ): OIDCDecodePayloadResponse {
+    ): OIDCDecodePayload {
         val rsaPublicKey = convertToRSAPublicKey(publicKey.n, publicKey.e)
         val claims = verifyTokenSignatureAndClaims(token, rsaPublicKey, expectedIssuer, expectedAudience)
 
-        return OIDCDecodePayloadResponse(
+        return OIDCDecodePayload(
             iss = claims.issuer,
             aud = claims.audience.toString(),
             sub = claims.subject, // String 그대로 사용 (Apple UUID)

--- a/src/main/kotlin/com/neki/auth/infra/oauth/helper/KakaoOauthHelper.kt
+++ b/src/main/kotlin/com/neki/auth/infra/oauth/helper/KakaoOauthHelper.kt
@@ -1,10 +1,10 @@
 package com.neki.auth.infra.oauth.helper
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.neki.auth.application.contract.OIDCDecodePayloadResponse
+import com.neki.auth.application.contract.OIDCDecodePayload
 import com.neki.auth.application.contract.OIDCPublicKeyDto
-import com.neki.auth.application.contract.OIDCPublicKeysResponse
-import com.neki.auth.application.contract.OauthInfoResponse
+import com.neki.auth.application.contract.OIDCPublicKeysPayload
+import com.neki.auth.application.contract.OauthInfoPayload
 import com.neki.auth.domain.Platform
 import com.neki.auth.infra.security.properties.OauthProperties
 import com.neki.common.api.dto.ResultCode
@@ -59,9 +59,9 @@ class KakaoOauthHelper(private val oauthProperties: OauthProperties, private val
      */
     override fun getOauthInfoByIdToken(
         idToken: String,
-        publicKeys: OIDCPublicKeysResponse,
+        publicKeys: OIDCPublicKeysPayload,
         platform: Platform,
-    ): OauthInfoResponse {
+    ): OauthInfoPayload {
         // Step 1: 헤더에서 kid 추출 (토큰 분리 및 Base64 디코딩)
         val kid = extractKidFromTokenHeader(idToken)
 
@@ -82,7 +82,7 @@ class KakaoOauthHelper(private val oauthProperties: OauthProperties, private val
             expectedAudience = expectedAudience,
         )
 
-        return OauthInfoResponse(
+        return OauthInfoPayload(
             providerType = ProviderType.KAKAO,
             oid = payload.sub,
             email = payload.email,
@@ -133,11 +133,11 @@ class KakaoOauthHelper(private val oauthProperties: OauthProperties, private val
         publicKey: OIDCPublicKeyDto,
         expectedIssuer: String,
         expectedAudience: String,
-    ): OIDCDecodePayloadResponse {
+    ): OIDCDecodePayload {
         val rsaPublicKey = convertToRSAPublicKey(publicKey.n, publicKey.e)
         val claims = verifyTokenSignatureAndClaims(token, rsaPublicKey, expectedIssuer, expectedAudience)
 
-        return OIDCDecodePayloadResponse(
+        return OIDCDecodePayload(
             iss = claims.issuer,
             aud = claims.audience.toString(),
             sub = claims.subject,

--- a/src/main/kotlin/com/neki/auth/infra/oauth/helper/OauthHelper.kt
+++ b/src/main/kotlin/com/neki/auth/infra/oauth/helper/OauthHelper.kt
@@ -1,7 +1,7 @@
 package com.neki.auth.infra.oauth.helper
 
-import com.neki.auth.application.contract.OIDCPublicKeysResponse
-import com.neki.auth.application.contract.OauthInfoResponse
+import com.neki.auth.application.contract.OIDCPublicKeysPayload
+import com.neki.auth.application.contract.OauthInfoPayload
 import com.neki.auth.domain.Platform
 
 /**
@@ -11,9 +11,5 @@ import com.neki.auth.domain.Platform
  * description    : OAuth OIDC 검증을 위한 Port
  */
 interface OauthHelper {
-    fun getOauthInfoByIdToken(
-        idToken: String,
-        publicKeys: OIDCPublicKeysResponse,
-        platform: Platform,
-    ): OauthInfoResponse
+    fun getOauthInfoByIdToken(idToken: String, publicKeys: OIDCPublicKeysPayload, platform: Platform): OauthInfoPayload
 }

--- a/src/main/kotlin/com/neki/auth/infra/oauth/oidc/AppleOidc.kt
+++ b/src/main/kotlin/com/neki/auth/infra/oauth/oidc/AppleOidc.kt
@@ -1,6 +1,6 @@
 package com.neki.auth.infra.oauth.oidc
 
-import com.neki.auth.application.contract.OIDCPublicKeysResponse
+import com.neki.auth.application.contract.OIDCPublicKeysPayload
 import com.neki.auth.infra.oauth.oidc.Oidc
 import com.neki.auth.infra.security.properties.OauthProperties
 import org.springframework.stereotype.Component
@@ -14,8 +14,8 @@ import org.springframework.web.client.RestClient
  */
 @Component
 class AppleOidc(private val restClient: RestClient, private val oauthProperties: OauthProperties) : Oidc {
-    override fun getOIDCPublicKey(): OIDCPublicKeysResponse = restClient.get()
+    override fun getOIDCPublicKey(): OIDCPublicKeysPayload = restClient.get()
         .uri(oauthProperties.apple.jwksUri)
         .retrieve()
-        .body(OIDCPublicKeysResponse::class.java)!!
+        .body(OIDCPublicKeysPayload::class.java)!!
 }

--- a/src/main/kotlin/com/neki/auth/infra/oauth/oidc/KakaoOidc.kt
+++ b/src/main/kotlin/com/neki/auth/infra/oauth/oidc/KakaoOidc.kt
@@ -1,7 +1,7 @@
 package com.neki.auth.infra.oauth.oidc
 
 import com.neki.auth.application.contract.AuthCacheKeys
-import com.neki.auth.application.contract.OIDCPublicKeysResponse
+import com.neki.auth.application.contract.OIDCPublicKeysPayload
 import com.neki.auth.infra.oauth.oidc.Oidc
 import com.neki.auth.infra.redis.AuthRedisCacheAdapter
 import com.neki.auth.infra.security.properties.OauthProperties
@@ -36,7 +36,7 @@ class KakaoOidc(
      * - TTL: 6시간
      * - 캐시 미스 시 카카오 API 호출 후 캐싱
      */
-    override fun getOIDCPublicKey(): OIDCPublicKeysResponse {
+    override fun getOIDCPublicKey(): OIDCPublicKeysPayload {
         // 1. 캐시 조회
         val cached = authRedisCacheAdapter.getPublicKeys(AuthCacheKeys.KAKAO_OIDC_KEY)
 
@@ -49,7 +49,7 @@ class KakaoOidc(
         val publicKeys = restClient.get()
             .uri(oauthProperties.kakao.jwksUri)
             .retrieve()
-            .body(OIDCPublicKeysResponse::class.java)!!
+            .body(OIDCPublicKeysPayload::class.java)!!
 
         // 3. 캐시 저장 (TTL 14일)
         authRedisCacheAdapter.setPublicKeys(AuthCacheKeys.KAKAO_OIDC_KEY, publicKeys, Duration.ofDays(14))

--- a/src/main/kotlin/com/neki/auth/infra/oauth/oidc/Oidc.kt
+++ b/src/main/kotlin/com/neki/auth/infra/oauth/oidc/Oidc.kt
@@ -1,6 +1,6 @@
 package com.neki.auth.infra.oauth.oidc
 
-import com.neki.auth.application.contract.OIDCPublicKeysResponse
+import com.neki.auth.application.contract.OIDCPublicKeysPayload
 
 /**
  * fileName       : Oidc
@@ -12,5 +12,5 @@ interface Oidc {
     /**
      * 카카오 OIDC 공개키 조회
      */
-    fun getOIDCPublicKey(): OIDCPublicKeysResponse
+    fun getOIDCPublicKey(): OIDCPublicKeysPayload
 }

--- a/src/main/kotlin/com/neki/auth/infra/redis/AuthRedisCacheAdapter.kt
+++ b/src/main/kotlin/com/neki/auth/infra/redis/AuthRedisCacheAdapter.kt
@@ -1,7 +1,7 @@
 package com.neki.auth.infra.redis
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.neki.auth.application.contract.OIDCPublicKeysResponse
+import com.neki.auth.application.contract.OIDCPublicKeysPayload
 import com.neki.auth.application.port.AuthCachePort
 import org.slf4j.LoggerFactory
 import org.springframework.data.redis.core.RedisTemplate
@@ -23,7 +23,7 @@ class AuthRedisCacheAdapter(
 
     private val log = LoggerFactory.getLogger(javaClass)
 
-    override fun setPublicKeys(key: String, value: OIDCPublicKeysResponse, ttl: Duration) {
+    override fun setPublicKeys(key: String, value: OIDCPublicKeysPayload, ttl: Duration) {
         try {
             redisTemplate.opsForValue().set(key, value, ttl)
         } catch (e: Exception) {
@@ -31,11 +31,11 @@ class AuthRedisCacheAdapter(
         }
     }
 
-    override fun getPublicKeys(key: String): OIDCPublicKeysResponse? {
+    override fun getPublicKeys(key: String): OIDCPublicKeysPayload? {
         val value = redisTemplate.opsForValue().get(key) ?: return null
 
         return try {
-            objectMapper.convertValue(value, OIDCPublicKeysResponse::class.java)
+            objectMapper.convertValue(value, OIDCPublicKeysPayload::class.java)
         } catch (e: Exception) {
             log.error("[AuthCache] Failed to deserialize OIDC public keys for key: $key", e)
             null

--- a/src/main/kotlin/com/neki/map/infra/client/kakao/KakaoLocalSearchPayload.kt
+++ b/src/main/kotlin/com/neki/map/infra/client/kakao/KakaoLocalSearchPayload.kt
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 /**
  * 카카오 맵 수집 데이터 DTO
  */
-data class KakaoLocalSearchResult(
+data class KakaoLocalSearchPayload(
     @JsonProperty("documents")
     val documents: List<KakaoPlace>,
 

--- a/src/main/kotlin/com/neki/map/infra/client/kakao/MapApiClientAdapter.kt
+++ b/src/main/kotlin/com/neki/map/infra/client/kakao/MapApiClientAdapter.kt
@@ -46,7 +46,7 @@ class MapApiClientAdapter(private val apiKey: String, private val restClient: Re
             }
             .header(HttpHeaders.AUTHORIZATION, "KakaoAK $apiKey")
             .retrieve()
-            .body(KakaoLocalSearchResult::class.java)
+            .body(KakaoLocalSearchPayload::class.java)
             ?: throw BusinessException(ResultCode.ERROR)
 
         return LocalSearchResult(

--- a/src/test/kotlin/com/neki/rule/ArchitectureRulesTest.kt
+++ b/src/test/kotlin/com/neki/rule/ArchitectureRulesTest.kt
@@ -1,0 +1,261 @@
+package com.neki.rule
+
+import com.tngtech.archunit.core.domain.JavaClasses
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeTests
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@DisplayName("아키텍처 규칙 검증")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ArchitectureRulesTest {
+
+    private lateinit var importedClasses: JavaClasses
+
+    @BeforeAll
+    fun setup() {
+        importedClasses = ClassFileImporter()
+            .withImportOption(DoNotIncludeTests())
+            .importPackages("com.neki")
+    }
+
+    @Nested
+    @DisplayName("레이어 의존성 규칙")
+    inner class LayerDependencies {
+
+        @Test
+        fun `Domain 계층은 Application 계층을 의존할 수 없다`() {
+            noClasses()
+                .that().resideInAnyPackage("..domain..")
+                .should().dependOnClassesThat().resideInAnyPackage("..application..")
+                .because("Domain layer must not depend on Application layer (Clean Architecture)")
+                .check(importedClasses)
+        }
+
+        @Test
+        fun `Domain 계층은 도메인별 API 계층을 의존할 수 없다`() {
+            noClasses()
+                .that().resideInAnyPackage("..domain..")
+                .should().dependOnClassesThat().resideInAnyPackage(
+                    "com.neki.auth.api..",
+                    "com.neki.user.api..",
+                    "com.neki.photo.api..",
+                    "com.neki.media.api..",
+                    "com.neki.pose.api..",
+                    "com.neki.map.api..",
+                    "com.neki.term.api..",
+                    "com.neki.version.api..",
+                ).because("Domain layer must not depend on API layer (common.api is allowed)")
+                .check(importedClasses)
+        }
+
+        @Test
+        fun `Domain 계층은 Infra 계층을 의존할 수 없다`() {
+            noClasses()
+                .that().resideInAnyPackage("..domain..")
+                .should().dependOnClassesThat().resideInAnyPackage("..infra..")
+                .because("Domain layer must not depend on Infrastructure layer (Clean Architecture)")
+                .check(importedClasses)
+        }
+
+        @Test
+        fun `Application 계층은 도메인별 API 계층을 의존할 수 없다`() {
+            noClasses()
+                .that().resideInAnyPackage("..application..")
+                .should().dependOnClassesThat().resideInAnyPackage(
+                    "com.neki.auth.api..",
+                    "com.neki.user.api..",
+                    "com.neki.photo.api..",
+                    "com.neki.media.api..",
+                    "com.neki.pose.api..",
+                    "com.neki.map.api..",
+                    "com.neki.term.api..",
+                    "com.neki.version.api..",
+                ).because("Application layer must not depend on API layer (common.api is allowed)")
+                .check(importedClasses)
+        }
+
+        // TODO: auth 도메인은 application→infra 의존이 존재 (OauthProperties, UserPrincipal)
+        //  장기적으로 리팩토링하여 이 예외를 제거해야 함
+        @Test
+        fun `Application 계층은 Infra 계층을 의존할 수 없다 (auth 도메인 제외)`() {
+            noClasses()
+                .that().resideInAnyPackage("..application..")
+                .and().resideOutsideOfPackage("com.neki.auth.application..")
+                .should().dependOnClassesThat().resideInAnyPackage("..infra..")
+                .because("Application layer must not depend on Infrastructure layer (auth domain excluded)")
+                .check(importedClasses)
+        }
+
+        @Test
+        fun `API 계층은 Infra 계층을 의존할 수 없다`() {
+            noClasses()
+                .that().resideInAnyPackage("..api..")
+                .and().resideOutsideOfPackage("com.neki.common.api..")
+                .should().dependOnClassesThat().resideInAnyPackage("..infra..")
+                .because("API layer must not depend on Infrastructure layer (Clean Architecture)")
+                .check(importedClasses)
+        }
+    }
+
+    @Nested
+    @DisplayName("Infra 레이어 규칙")
+    inner class InfraLayerRules {
+
+        @Test
+        fun `Infra 계층은 도메인별 API 계층을 의존할 수 없다`() {
+            noClasses()
+                .that().resideInAnyPackage("..infra..")
+                .should().dependOnClassesThat().resideInAnyPackage(
+                    "com.neki.auth.api..",
+                    "com.neki.user.api..",
+                    "com.neki.photo.api..",
+                    "com.neki.media.api..",
+                    "com.neki.pose.api..",
+                    "com.neki.map.api..",
+                    "com.neki.term.api..",
+                    "com.neki.version.api..",
+                ).because("Infrastructure layer must not depend on domain API packages (common.api is allowed)")
+                .check(importedClasses)
+        }
+    }
+
+    @Nested
+    @DisplayName("도메인 격리 규칙")
+    inner class DomainIsolation {
+
+        // 위반 없는 도메인에 대해 격리 규칙 적용
+        // auth ↔ user: 문서에 명시된 예외 (인증-사용자 결합)
+        // map → photo: 기존 위반 (MediaClientPort → MediaStorageInfo), 장기적으로 수정 필요
+
+        private val allDomainPackages = listOf(
+            "com.neki.auth",
+            "com.neki.user",
+            "com.neki.photo",
+            "com.neki.media",
+            "com.neki.pose",
+            "com.neki.map",
+            "com.neki.term",
+            "com.neki.version",
+        )
+
+        private fun otherDomainPackages(domain: String): Array<String> = allDomainPackages
+            .filter { !it.endsWith(domain) }
+            .map { "$it.." }
+            .toTypedArray()
+
+        @Test
+        fun `photo 도메인은 다른 도메인에 의존할 수 없다`() {
+            noClasses()
+                .that().resideInAnyPackage(
+                    "com.neki.photo.api..",
+                    "com.neki.photo.application..",
+                    "com.neki.photo.domain..",
+                ).should().dependOnClassesThat().resideInAnyPackage(*otherDomainPackages("photo"))
+                .because("photo domain (api/application/domain) must not depend on other domains")
+                .check(importedClasses)
+        }
+
+        @Test
+        fun `media 도메인은 다른 도메인에 의존할 수 없다`() {
+            noClasses()
+                .that().resideInAnyPackage(
+                    "com.neki.media.api..",
+                    "com.neki.media.application..",
+                    "com.neki.media.domain..",
+                ).should().dependOnClassesThat().resideInAnyPackage(*otherDomainPackages("media"))
+                .because("media domain (api/application/domain) must not depend on other domains")
+                .check(importedClasses)
+        }
+
+        @Test
+        fun `pose 도메인은 다른 도메인에 의존할 수 없다`() {
+            noClasses()
+                .that().resideInAnyPackage(
+                    "com.neki.pose.api..",
+                    "com.neki.pose.application..",
+                    "com.neki.pose.domain..",
+                ).should().dependOnClassesThat().resideInAnyPackage(*otherDomainPackages("pose"))
+                .because("pose domain (api/application/domain) must not depend on other domains")
+                .check(importedClasses)
+        }
+
+        @Test
+        fun `term 도메인은 다른 도메인에 의존할 수 없다`() {
+            noClasses()
+                .that().resideInAnyPackage(
+                    "com.neki.term.api..",
+                    "com.neki.term.application..",
+                    "com.neki.term.domain..",
+                ).should().dependOnClassesThat().resideInAnyPackage(*otherDomainPackages("term"))
+                .because("term domain (api/application/domain) must not depend on other domains")
+                .check(importedClasses)
+        }
+
+        @Test
+        fun `version 도메인은 다른 도메인에 의존할 수 없다`() {
+            noClasses()
+                .that().resideInAnyPackage(
+                    "com.neki.version.api..",
+                    "com.neki.version.application..",
+                    "com.neki.version.domain..",
+                ).should().dependOnClassesThat().resideInAnyPackage(*otherDomainPackages("version"))
+                .because("version domain (api/application/domain) must not depend on other domains")
+                .check(importedClasses)
+        }
+    }
+
+    @Nested
+    @DisplayName("어노테이션 배치 규칙")
+    inner class AnnotationPlacement {
+
+        @Test
+        fun `@UseCase는 application usecase 패키지에만 위치해야 한다`() {
+            classes()
+                .that().areAnnotatedWith(com.neki.common.annotation.UseCase::class.java)
+                .should().resideInAnyPackage("..application.usecase..")
+                .because("@UseCase annotation should only be used in application.usecase packages")
+                .check(importedClasses)
+        }
+
+        @Test
+        fun `@RestController는 api controller 패키지에만 위치해야 한다`() {
+            classes()
+                .that().areAnnotatedWith(org.springframework.web.bind.annotation.RestController::class.java)
+                .should().resideInAnyPackage("..api.controller..")
+                .because("@RestController should only be used in api.controller packages")
+                .check(importedClasses)
+        }
+
+        @Test
+        fun `@Repository는 infra 패키지에만 위치해야 한다`() {
+            classes()
+                .that().areAnnotatedWith(org.springframework.stereotype.Repository::class.java)
+                .should().resideInAnyPackage("..infra..")
+                .because("@Repository should only be used in infra packages")
+                .check(importedClasses)
+        }
+    }
+
+    @Nested
+    @DisplayName("포트/어댑터 패턴 규칙")
+    inner class PortAdapterPattern {
+
+        // TODO: auth 도메인은 UseCase→infra 의존이 존재 (OauthProperties, UserPrincipal)
+        //  장기적으로 리팩토링하여 이 예외를 제거해야 함
+        @Test
+        fun `@UseCase 클래스는 infra 계층을 의존할 수 없다 (auth 도메인 제외)`() {
+            noClasses()
+                .that().areAnnotatedWith(com.neki.common.annotation.UseCase::class.java)
+                .and().resideOutsideOfPackage("com.neki.auth..")
+                .should().dependOnClassesThat().resideInAnyPackage("..infra..")
+                .because("@UseCase classes must depend on ports, not infrastructure (auth domain excluded)")
+                .check(importedClasses)
+        }
+    }
+}

--- a/src/test/kotlin/com/neki/rule/ArchitectureRulesTest.kt
+++ b/src/test/kotlin/com/neki/rule/ArchitectureRulesTest.kt
@@ -10,10 +10,38 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 
 @DisplayName("아키텍처 규칙 검증")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ArchitectureRulesTest {
+
+    companion object {
+        private val ALL_DOMAIN_PACKAGES = listOf(
+            "com.neki.auth",
+            "com.neki.user",
+            "com.neki.photo",
+            "com.neki.media",
+            "com.neki.pose",
+            "com.neki.map",
+            "com.neki.term",
+            "com.neki.version",
+        )
+
+        /** 격리 검증 대상 도메인 (auth, user, map은 알려진 예외로 제외) */
+        private val ISOLATED_DOMAINS = listOf("photo", "media", "pose", "term", "version")
+
+        private fun domainApiPackages(): Array<String> = ALL_DOMAIN_PACKAGES.map { "$it.api.." }.toTypedArray()
+
+        private fun otherDomainPackages(domain: String): Array<String> = ALL_DOMAIN_PACKAGES
+            .filter { !it.endsWith(domain) }
+            .map { "$it.." }
+            .toTypedArray()
+
+        @JvmStatic
+        fun isolatedDomains(): List<String> = ISOLATED_DOMAINS
+    }
 
     private lateinit var importedClasses: JavaClasses
 
@@ -41,16 +69,8 @@ class ArchitectureRulesTest {
         fun `Domain 계층은 도메인별 API 계층을 의존할 수 없다`() {
             noClasses()
                 .that().resideInAnyPackage("..domain..")
-                .should().dependOnClassesThat().resideInAnyPackage(
-                    "com.neki.auth.api..",
-                    "com.neki.user.api..",
-                    "com.neki.photo.api..",
-                    "com.neki.media.api..",
-                    "com.neki.pose.api..",
-                    "com.neki.map.api..",
-                    "com.neki.term.api..",
-                    "com.neki.version.api..",
-                ).because("Domain layer must not depend on API layer (common.api is allowed)")
+                .should().dependOnClassesThat().resideInAnyPackage(*domainApiPackages())
+                .because("Domain layer must not depend on API layer (common.api is allowed)")
                 .check(importedClasses)
         }
 
@@ -67,16 +87,8 @@ class ArchitectureRulesTest {
         fun `Application 계층은 도메인별 API 계층을 의존할 수 없다`() {
             noClasses()
                 .that().resideInAnyPackage("..application..")
-                .should().dependOnClassesThat().resideInAnyPackage(
-                    "com.neki.auth.api..",
-                    "com.neki.user.api..",
-                    "com.neki.photo.api..",
-                    "com.neki.media.api..",
-                    "com.neki.pose.api..",
-                    "com.neki.map.api..",
-                    "com.neki.term.api..",
-                    "com.neki.version.api..",
-                ).because("Application layer must not depend on API layer (common.api is allowed)")
+                .should().dependOnClassesThat().resideInAnyPackage(*domainApiPackages())
+                .because("Application layer must not depend on API layer (common.api is allowed)")
                 .check(importedClasses)
         }
 
@@ -111,16 +123,8 @@ class ArchitectureRulesTest {
         fun `Infra 계층은 도메인별 API 계층을 의존할 수 없다`() {
             noClasses()
                 .that().resideInAnyPackage("..infra..")
-                .should().dependOnClassesThat().resideInAnyPackage(
-                    "com.neki.auth.api..",
-                    "com.neki.user.api..",
-                    "com.neki.photo.api..",
-                    "com.neki.media.api..",
-                    "com.neki.pose.api..",
-                    "com.neki.map.api..",
-                    "com.neki.term.api..",
-                    "com.neki.version.api..",
-                ).because("Infrastructure layer must not depend on domain API packages (common.api is allowed)")
+                .should().dependOnClassesThat().resideInAnyPackage(*domainApiPackages())
+                .because("Infrastructure layer must not depend on domain API packages (common.api is allowed)")
                 .check(importedClasses)
         }
     }
@@ -133,79 +137,16 @@ class ArchitectureRulesTest {
         // auth ↔ user: 문서에 명시된 예외 (인증-사용자 결합)
         // map → photo: 기존 위반 (MediaClientPort → MediaStorageInfo), 장기적으로 수정 필요
 
-        private val allDomainPackages = listOf(
-            "com.neki.auth",
-            "com.neki.user",
-            "com.neki.photo",
-            "com.neki.media",
-            "com.neki.pose",
-            "com.neki.map",
-            "com.neki.term",
-            "com.neki.version",
-        )
-
-        private fun otherDomainPackages(domain: String): Array<String> = allDomainPackages
-            .filter { !it.endsWith(domain) }
-            .map { "$it.." }
-            .toTypedArray()
-
-        @Test
-        fun `photo 도메인은 다른 도메인에 의존할 수 없다`() {
+        @ParameterizedTest(name = "{0} 도메인은 다른 도메인에 의존할 수 없다")
+        @MethodSource("com.neki.rule.ArchitectureRulesTest#isolatedDomains")
+        fun `격리된 도메인은 다른 도메인에 의존할 수 없다`(domain: String) {
             noClasses()
                 .that().resideInAnyPackage(
-                    "com.neki.photo.api..",
-                    "com.neki.photo.application..",
-                    "com.neki.photo.domain..",
-                ).should().dependOnClassesThat().resideInAnyPackage(*otherDomainPackages("photo"))
-                .because("photo domain (api/application/domain) must not depend on other domains")
-                .check(importedClasses)
-        }
-
-        @Test
-        fun `media 도메인은 다른 도메인에 의존할 수 없다`() {
-            noClasses()
-                .that().resideInAnyPackage(
-                    "com.neki.media.api..",
-                    "com.neki.media.application..",
-                    "com.neki.media.domain..",
-                ).should().dependOnClassesThat().resideInAnyPackage(*otherDomainPackages("media"))
-                .because("media domain (api/application/domain) must not depend on other domains")
-                .check(importedClasses)
-        }
-
-        @Test
-        fun `pose 도메인은 다른 도메인에 의존할 수 없다`() {
-            noClasses()
-                .that().resideInAnyPackage(
-                    "com.neki.pose.api..",
-                    "com.neki.pose.application..",
-                    "com.neki.pose.domain..",
-                ).should().dependOnClassesThat().resideInAnyPackage(*otherDomainPackages("pose"))
-                .because("pose domain (api/application/domain) must not depend on other domains")
-                .check(importedClasses)
-        }
-
-        @Test
-        fun `term 도메인은 다른 도메인에 의존할 수 없다`() {
-            noClasses()
-                .that().resideInAnyPackage(
-                    "com.neki.term.api..",
-                    "com.neki.term.application..",
-                    "com.neki.term.domain..",
-                ).should().dependOnClassesThat().resideInAnyPackage(*otherDomainPackages("term"))
-                .because("term domain (api/application/domain) must not depend on other domains")
-                .check(importedClasses)
-        }
-
-        @Test
-        fun `version 도메인은 다른 도메인에 의존할 수 없다`() {
-            noClasses()
-                .that().resideInAnyPackage(
-                    "com.neki.version.api..",
-                    "com.neki.version.application..",
-                    "com.neki.version.domain..",
-                ).should().dependOnClassesThat().resideInAnyPackage(*otherDomainPackages("version"))
-                .because("version domain (api/application/domain) must not depend on other domains")
+                    "com.neki.$domain.api..",
+                    "com.neki.$domain.application..",
+                    "com.neki.$domain.domain..",
+                ).should().dependOnClassesThat().resideInAnyPackage(*otherDomainPackages(domain))
+                .because("$domain domain (api/application/domain) must not depend on other domains")
                 .check(importedClasses)
         }
     }

--- a/src/test/kotlin/com/neki/rule/ArchitectureRulesTest.kt
+++ b/src/test/kotlin/com/neki/rule/ArchitectureRulesTest.kt
@@ -243,6 +243,47 @@ class ArchitectureRulesTest {
     }
 
     @Nested
+    @DisplayName("DTO 배치 규칙")
+    inner class DtoPlacement {
+
+        @Test
+        fun `Request 클래스는 api 계층에만 위치해야 한다`() {
+            classes()
+                .that().haveSimpleNameEndingWith("Request")
+                .should().resideInAnyPackage("..api..")
+                .because("Request DTOs should only be in the API layer")
+                .check(importedClasses)
+        }
+
+        @Test
+        fun `Response 클래스는 api 계층에만 위치해야 한다`() {
+            classes()
+                .that().haveSimpleNameEndingWith("Response")
+                .should().resideInAnyPackage("..api..")
+                .because("Response DTOs should only be in the API layer")
+                .check(importedClasses)
+        }
+
+        @Test
+        fun `Command 클래스는 application 계층에만 위치해야 한다`() {
+            classes()
+                .that().haveSimpleNameEndingWith("Command")
+                .should().resideInAnyPackage("..application..")
+                .because("Command DTOs should only be in the Application layer")
+                .check(importedClasses)
+        }
+
+        @Test
+        fun `Result 클래스는 application 계층에만 위치해야 한다`() {
+            classes()
+                .that().haveSimpleNameEndingWith("Result")
+                .should().resideInAnyPackage("..application..")
+                .because("Result DTOs should only be in the Application layer")
+                .check(importedClasses)
+        }
+    }
+
+    @Nested
     @DisplayName("포트/어댑터 패턴 규칙")
     inner class PortAdapterPattern {
 


### PR DESCRIPTION
## summary
- 계층간 의존성을 명시적으로 추가
- claude code spotless, test hooks 추가

## details

### 계층간 의존성을 명시적으로 추가
- archunit을 이용해 계층간 의존성을 테스트로 명시적으로 관리
- 도메인간 의존 방지

### claude code spotless, test hooks 추가
- claude code 응답이 완료되는 시점에 spotless와 test를 실행하도록 hook 추가