### PR TITLE
fix/#150: 네컷사진 삭제 시 Soft Delete 로 변경

### DIFF
--- a/src/main/kotlin/com/neki/media/application/port/MediaRepositoryPort.kt
+++ b/src/main/kotlin/com/neki/media/application/port/MediaRepositoryPort.kt
@@ -17,6 +17,7 @@ interface MediaRepositoryPort {
     fun getMediaForUploadConfirmation(ownerId: Long, ids: List<Long>): List<Media>
 
     fun save(media: Media): Media
+    fun saveAll(medias: List<Media>): List<Media>
 
     fun delete(id: Long)
     fun deleteAll(ids: List<Long>)

--- a/src/main/kotlin/com/neki/media/application/usecase/DeleteMediaUseCase.kt
+++ b/src/main/kotlin/com/neki/media/application/usecase/DeleteMediaUseCase.kt
@@ -8,7 +8,6 @@ import com.neki.media.application.command.DeleteMediaCommand
 import com.neki.media.application.command.DeleteMediasCommand
 import com.neki.media.application.port.MediaBinaryCachePort
 import com.neki.media.application.port.MediaRepositoryPort
-import com.neki.media.application.port.MediaStoragePort
 import org.slf4j.LoggerFactory
 
 /**
@@ -22,7 +21,6 @@ import org.slf4j.LoggerFactory
 @UseCase
 class DeleteMediaUseCase(
     private val mediaRepository: MediaRepositoryPort,
-    private val mediaStorage: MediaStoragePort,
     private val cache: MediaBinaryCachePort,
     private val transactionRunner: TransactionRunner,
 ) {
@@ -33,83 +31,29 @@ class DeleteMediaUseCase(
      * media 단건 삭제 usecase
      */
     fun execute(command: DeleteMediaCommand) {
-        // DB media metadata 삭제
         val media = transactionRunner.run {
             val foundMedia = mediaRepository.getActiveMedia(command.ownerId, command.mediaId)
                 ?: throw BusinessException(ResultCode.NOT_FOUND)
 
-            foundMedia.markAsDeleteRequested()
+            foundMedia.markAsDeleted()
+            mediaRepository.save(foundMedia)
             foundMedia
         }
 
-        cache.evict(media.storageKey) // cache 무효화 시도
-
-        return runCatching {
-            // object storage 삭제 요청
-            mediaStorage.deleteByKey(media.storageKey)
-        }.fold(
-            onSuccess = {
-                transactionRunner.runNew {
-                    // 추후 scheduling 검토
-                    mediaRepository.delete(media.id!!)
-                }
-            },
-            onFailure = { e ->
-                log.warn(
-                    "Media delete failed. Will retry later. fileId={}, key={}",
-                    media.id,
-                    media.storageKey,
-                    e,
-                )
-            },
-        )
-
-        // TODO : object storage 삭제 실패한 media에 대해 삭제 필요
+        cache.evict(media.storageKey)
     }
 
     /**
      * media bulk 삭제 usecase
      */
     fun execute(command: DeleteMediasCommand) {
-        // 삭제할 media 조회
         val medias = transactionRunner.run {
-            val foundMedias =
-                mediaRepository.getActiveMedias(command.ownerId, command.mediaIds)
-
-            foundMedias.forEach {
-                it.markAsDeleteRequested()
-                cache.evict(it.storageKey) // cache 무효화 시도
-            }
+            val foundMedias = mediaRepository.getActiveMedias(command.ownerId, command.mediaIds)
+            foundMedias.forEach { it.markAsDeleted() }
+            mediaRepository.saveAll(foundMedias)
             foundMedias
         }
 
-        val deletedMediaIds = mutableListOf<Long>()
-        val failedMedias = mutableListOf<Long>()
-
-        // object storage 삭제
-        medias.forEach { media ->
-            runCatching {
-                mediaStorage.deleteByKey(media.storageKey)
-            }.onSuccess {
-                deletedMediaIds.add(media.id!!)
-            }.onFailure { e ->
-                failedMedias.add(media.id!!)
-                log.warn(
-                    "Media delete failed. Will retry later. mediaId={}, key={}",
-                    media.id,
-                    media.storageKey,
-                    e,
-                )
-            }
-        }
-
-        // object storage 삭제 성공한 오브젝트에 대해 DB soft delete
-        if (deletedMediaIds.isNotEmpty()) {
-            transactionRunner.runNew {
-                mediaRepository.deleteAll(deletedMediaIds)
-            }
-        }
-
-        // TODO : object storage 삭제 실패한 media에 대해 삭제 필요
+        medias.forEach { cache.evict(it.storageKey) }
     }
 }

--- a/src/main/kotlin/com/neki/media/infra/persist/MediaRepositoryAdapter.kt
+++ b/src/main/kotlin/com/neki/media/infra/persist/MediaRepositoryAdapter.kt
@@ -35,6 +35,8 @@ class MediaRepositoryAdapter(private val jpaRepository: JpaMediaRepository) : Me
 
     override fun save(media: Media): Media = jpaRepository.save(media)
 
+    override fun saveAll(medias: List<Media>): List<Media> = jpaRepository.saveAll(medias)
+
     override fun delete(id: Long) {
         jpaRepository.deleteById(id)
     }

--- a/src/main/kotlin/com/neki/photo/domain/entity/PhotoImage.kt
+++ b/src/main/kotlin/com/neki/photo/domain/entity/PhotoImage.kt
@@ -8,6 +8,8 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.annotations.DynamicUpdate
+import org.hibernate.annotations.SQLRestriction
+import java.time.LocalDateTime
 
 /**
  * fileName       : PhotoImage
@@ -17,6 +19,7 @@ import org.hibernate.annotations.DynamicUpdate
  */
 @Entity
 @DynamicUpdate
+@SQLRestriction("deleted_at IS NULL")
 @Table(name = "TB_PHOTO_IMAGE")
 class PhotoImage(
     @Id
@@ -34,4 +37,13 @@ class PhotoImage(
 
     @Column(name = "memo", nullable = true)
     var memo: String? = null,
-) : BaseTimeEntity()
+
+    @Column(name = "deleted_at", nullable = true)
+    var deletedAt: LocalDateTime? = null,
+) : BaseTimeEntity() {
+
+    fun softDelete() {
+        folderId = null
+        deletedAt = LocalDateTime.now()
+    }
+}

--- a/src/main/kotlin/com/neki/photo/infra/persist/PhotoImageRepositoryAdapter.kt
+++ b/src/main/kotlin/com/neki/photo/infra/persist/PhotoImageRepositoryAdapter.kt
@@ -61,7 +61,8 @@ class PhotoImageRepositoryAdapter(
             return emptyList()
         }
 
-        jpaRepository.deleteAll(photos)
+        photos.forEach { it.softDelete() }
+        jpaRepository.saveAll(photos)
         jpaRepository.flush()
 
         return photos

--- a/src/main/kotlin/com/neki/photo/infra/persist/jpa/PhotoImageQueryRepository.kt
+++ b/src/main/kotlin/com/neki/photo/infra/persist/jpa/PhotoImageQueryRepository.kt
@@ -131,7 +131,7 @@ class PhotoImageQueryRepository(private val queryFactory: JPAQueryFactory) {
         return queryFactory
             .update(photoImage)
             .setNull(photoImage.folderId)
-            .where(photoImage.userId.eq(userId), photoImage.folderId.`in`(folderIds))
+            .where(photoImage.userId.eq(userId), photoImage.folderId.`in`(folderIds), photoImage.deletedAt.isNull)
             .execute().toInt()
     }
 
@@ -169,6 +169,7 @@ class PhotoImageQueryRepository(private val queryFactory: JPAQueryFactory) {
                 photoImage.userId.eq(userId),
                 photoImage.folderId.eq(folderId),
                 photoImage.id.`in`(photoIds),
+                photoImage.deletedAt.isNull,
             )
             .execute().toInt()
     }

--- a/src/main/resources/db/migration/V12__add_soft_delete_to_photo_image.sql
+++ b/src/main/resources/db/migration/V12__add_soft_delete_to_photo_image.sql
@@ -1,0 +1,11 @@
+-- deleted_at 컬럼 추가 (soft delete용)
+ALTER TABLE TB_PHOTO_IMAGE ADD COLUMN deleted_at TIMESTAMP NULL;
+
+-- 기존 unique constraint 제거
+-- soft-deleted 레코드까지 포함하면 삭제 후 같은 미디어 재등록 시 unique violation 발생
+ALTER TABLE TB_PHOTO_IMAGE DROP CONSTRAINT uk_photo_image_media_id;
+
+-- Partial Unique Index로 교체 (deleted_at IS NULL인 레코드에만 unique 보장)
+CREATE UNIQUE INDEX uk_photo_image_media_id
+    ON TB_PHOTO_IMAGE (media_id)
+    WHERE deleted_at IS NULL;


### PR DESCRIPTION
## Description
- 데이터보존 및 추적을 위해 Hard Delete -> Soft Delete로 변경 작업

## Action Item
- [x] 이미지 삭제 시 photo_image 테이블에 삭제할 row에 folder_id를 null로 변경 후 delete_at 값을 현재시간으로 변경
- [x] photo_image 테이블에 `@SQLRestriction("deleted_at IS NULL")` 을 추가하여 조회 시 기본으로 where deleted_at is null 조건 추가
- [x] media 테이블의 경우도 status를 DELETED로 변경 (기존에는 삭제였음) S3 스토리지의 값도 삭제 안하도록 수정