### PR TITLE
fix: 사용자명 10글자 제한

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -83,6 +83,7 @@ Before starting any task, load the relevant context document:
 | Follow existing package structure | Maintainability |
 | Run `spotlessApply` before commit | Code style consistency |
 | Delete dependent entities first | Prevents orphan records and FK violations |
+| Add Flyway migration when changing DB schema | `@Column` length, type, constraint 변경 시 `src/main/resources/db/migration/` 에 다음 버전의 SQL 파일 추가 필수 |
 
 ---
 

--- a/src/main/kotlin/com/neki/user/api/dto/UserRequest.kt
+++ b/src/main/kotlin/com/neki/user/api/dto/UserRequest.kt
@@ -11,8 +11,8 @@ import jakarta.validation.constraints.Size
  * description    :
  */
 data class UpdateUserRequest(
-    @field:Schema(description = "공백을 포함해 12글자 이하로 변경할 닉네임을 설정합니다", example = "새로운닉네임")
-    @field:Size(max = 12, message = "닉네임은 공백 포함 12자 이하여야 합니다.")
+    @field:Schema(description = "공백을 포함해 10글자 이하로 변경할 닉네임을 설정합니다", example = "새로운닉네임")
+    @field:Size(max = 10, message = "닉네임은 공백 포함 10자 이하여야 합니다.")
     @field:NotBlank(message = "닉네임은 공백일 수 없습니다")
     val name: String,
 )

--- a/src/main/kotlin/com/neki/user/domain/entity/User.kt
+++ b/src/main/kotlin/com/neki/user/domain/entity/User.kt
@@ -29,7 +29,7 @@ class User(
     @Column(nullable = true, length = 255)
     var oid: String?,
 
-    @Column(nullable = false, length = 12)
+    @Column(nullable = false, length = 10)
     var name: String?,
 
     @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/com/neki/user/infra/generator/NicknameGenerator.kt
+++ b/src/main/kotlin/com/neki/user/infra/generator/NicknameGenerator.kt
@@ -38,7 +38,7 @@ class NicknameGenerator(private val userRepository: UserRepository) : NicknameGe
             val adjective = ADJECTIVES.random()
             val noun = NOUNS.random()
             val number = (MIN_NUMBER..MAX_NUMBER).random()
-            val nickname = "$adjective $noun-$number"
+            val nickname = "$adjective$noun-$number"
             if (nickname.length <= MAX_LENGTH && !userRepository.existsByName(nickname)) {
                 return nickname
             }
@@ -47,7 +47,7 @@ class NicknameGenerator(private val userRepository: UserRepository) : NicknameGe
         // fallback: 타임스탬프 기반 2자리
         val adjective = ADJECTIVES.random()
         val noun = NOUNS.random()
-        val nickname = "$adjective $noun-${System.currentTimeMillis() % FALLBACK_MODULO}"
+        val nickname = "$adjective$noun-${System.currentTimeMillis() % FALLBACK_MODULO}"
         return nickname.take(MAX_LENGTH)
     }
 }

--- a/src/main/kotlin/com/neki/user/infra/generator/NicknameGenerator.kt
+++ b/src/main/kotlin/com/neki/user/infra/generator/NicknameGenerator.kt
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component
 /**
  * fileName       : NicknameGenerator
  * author         : koo
- * date           : 2026. 1. 28.
+ * date           : 2026. 2. 28.
  * description    : 랜덤 닉네임 생성기 구현체
  */
 @Component
@@ -30,22 +30,24 @@ class NicknameGenerator(private val userRepository: UserRepository) : NicknameGe
         private const val MIN_NUMBER = 1
         private const val MAX_NUMBER = 99
         private const val FALLBACK_MODULO = 100
+        private const val MAX_LENGTH = 10
     }
 
     override fun generateUniqueNickname(): String {
-        val adjective = ADJECTIVES.random()
-        val noun = NOUNS.random()
-        val baseName = "$adjective $noun"
-
         repeat(MAX_RETRY_COUNT) {
+            val adjective = ADJECTIVES.random()
+            val noun = NOUNS.random()
             val number = (MIN_NUMBER..MAX_NUMBER).random()
-            val nickname = "$baseName-$number"
-            if (!userRepository.existsByName(nickname)) {
+            val nickname = "$adjective $noun-$number"
+            if (nickname.length <= MAX_LENGTH && !userRepository.existsByName(nickname)) {
                 return nickname
             }
         }
 
         // fallback: 타임스탬프 기반 2자리
-        return "$baseName-${System.currentTimeMillis() % FALLBACK_MODULO}"
+        val adjective = ADJECTIVES.random()
+        val noun = NOUNS.random()
+        val nickname = "$adjective $noun-${System.currentTimeMillis() % FALLBACK_MODULO}"
+        return nickname.take(MAX_LENGTH)
     }
 }

--- a/src/main/resources/db/migration/V14__alter_users_name_length_to_10.sql
+++ b/src/main/resources/db/migration/V14__alter_users_name_length_to_10.sql
@@ -1,0 +1,2 @@
+-- 사용자 닉네임 최대 길이를 10자로 제한
+ALTER TABLE TB_USERS ALTER COLUMN name TYPE VARCHAR(10);


### PR DESCRIPTION
## summary
- 사용자 랜덤 닉네임의 글자 수를 10자로 제한
- 스키마 변경 시 flyway 변경을 하도록 CLAUDE.md 문서 업데이트