### PR TITLE
fix: uploadMethod NotNull validate 제거

### DIFF
--- a/src/main/kotlin/com/neki/photo/api/converter/PhotoImageCommandConverter.kt
+++ b/src/main/kotlin/com/neki/photo/api/converter/PhotoImageCommandConverter.kt
@@ -27,7 +27,7 @@ class PhotoImageCommandConverter {
         uploads = request.uploads.map { item ->
             UploadPhotoCommand.UploadItem(
                 mediaId = item.mediaId!!,
-                uploadMethod = item.uploadMethod!!,
+                uploadMethod = item.uploadMethod,
                 memo = item.memo,
                 capturedAt = item.capturedAt,
             )

--- a/src/main/kotlin/com/neki/photo/api/dto/PhotoImageRequest.kt
+++ b/src/main/kotlin/com/neki/photo/api/dto/PhotoImageRequest.kt
@@ -36,7 +36,6 @@ data class UploadPhotoRequest(
             example = "QR",
             allowableValues = ["QR", "DIRECT_UPLOAD"],
         )
-        @field:NotNull(message = "uploadMethod는 필수 입력값입니다.")
         val uploadMethod: UploadMethod? = null,
 
         @field:Schema(description = "메모", example = "대학교 친구들이랑")

--- a/src/main/kotlin/com/neki/photo/application/command/PhotoImageCommand.kt
+++ b/src/main/kotlin/com/neki/photo/application/command/PhotoImageCommand.kt
@@ -18,7 +18,7 @@ data class UploadPhotoCommand(
 ) {
     data class UploadItem(
         val mediaId: Long,
-        val uploadMethod: UploadMethod,
+        val uploadMethod: UploadMethod?,
         val memo: String?,
         val capturedAt: LocalDateTime?,
     )


### PR DESCRIPTION
## Description
- 사진 등록 API 중 uploadMethod 항목 `@NotNull` 제거
- iOS, Android 배포 시점이 다르므로 호환되도록 필수 검증 제거