### PR TITLE
feat/#178: 사진-폴더 중간 테이블 생성

### DIFF
--- a/src/main/kotlin/com/neki/photo/application/port/PhotoImageFolderRepositoryPort.kt
+++ b/src/main/kotlin/com/neki/photo/application/port/PhotoImageFolderRepositoryPort.kt
@@ -1,0 +1,12 @@
+package com.neki.photo.application.port
+
+interface PhotoImageFolderRepositoryPort {
+
+    fun saveAll(photoImageIds: List<Long>, folderId: Long)
+
+    fun deleteByPhotoImageIds(photoImageIds: List<Long>)
+
+    fun deleteByFolderIds(folderIds: List<Long>)
+
+    fun deleteByPhotoImageIdsAndFolderId(photoImageIds: List<Long>, folderId: Long)
+}

--- a/src/main/kotlin/com/neki/photo/application/usecase/DeleteFoldersUseCase.kt
+++ b/src/main/kotlin/com/neki/photo/application/usecase/DeleteFoldersUseCase.kt
@@ -8,6 +8,7 @@ import com.neki.photo.application.command.DeleteFoldersCommand
 import com.neki.photo.application.port.FavoriteImageRepositoryPort
 import com.neki.photo.application.port.FolderRepositoryPort
 import com.neki.photo.application.port.MediaClientPort
+import com.neki.photo.application.port.PhotoImageFolderRepositoryPort
 import com.neki.photo.application.port.PhotoImageRepositoryPort
 import com.neki.photo.domain.entity.PhotoImage
 
@@ -21,6 +22,7 @@ import com.neki.photo.domain.entity.PhotoImage
 class DeleteFoldersUseCase(
     private val folderRepository: FolderRepositoryPort,
     private val photoImageRepository: PhotoImageRepositoryPort,
+    private val photoImageFolderRepository: PhotoImageFolderRepositoryPort,
     private val favoriteImageRepository: FavoriteImageRepositoryPort,
     private val mediaClient: MediaClientPort,
     private val transactionRunner: TransactionRunner,
@@ -46,6 +48,9 @@ class DeleteFoldersUseCase(
                 // 사진 삭제를 하지 않는 경우 사진에서 folderId만 없앰
                 photoImageRepository.updatePhotosFolderIdToNull(command.userId, command.folderIds)
             }
+
+            // 중간 테이블에서 폴더 연관 삭제 (dual-write)
+            photoImageFolderRepository.deleteByFolderIds(command.folderIds)
 
             // 폴더 삭제
             val deletedCount: Int = folderRepository.deleteOwnedFolders(

--- a/src/main/kotlin/com/neki/photo/application/usecase/RemovePhotosFromFolderUseCase.kt
+++ b/src/main/kotlin/com/neki/photo/application/usecase/RemovePhotosFromFolderUseCase.kt
@@ -5,6 +5,7 @@ import com.neki.common.api.dto.ResultCode
 import com.neki.common.exception.BusinessException
 import com.neki.photo.application.command.RemovePhotosFromFolderCommand
 import com.neki.photo.application.port.FolderRepositoryPort
+import com.neki.photo.application.port.PhotoImageFolderRepositoryPort
 import com.neki.photo.application.port.PhotoImageRepositoryPort
 import org.springframework.transaction.annotation.Transactional
 
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional
 class RemovePhotosFromFolderUseCase(
     private val folderRepository: FolderRepositoryPort,
     private val photoImageRepository: PhotoImageRepositoryPort,
+    private val photoImageFolderRepository: PhotoImageFolderRepositoryPort,
 ) {
 
     @Transactional
@@ -32,5 +34,8 @@ class RemovePhotosFromFolderUseCase(
             command.folderId,
             command.photoIds,
         )
+
+        // 중간 테이블에서도 연관 삭제 (dual-write)
+        photoImageFolderRepository.deleteByPhotoImageIdsAndFolderId(command.photoIds, command.folderId)
     }
 }

--- a/src/main/kotlin/com/neki/photo/application/usecase/UploadPhotosUseCase.kt
+++ b/src/main/kotlin/com/neki/photo/application/usecase/UploadPhotosUseCase.kt
@@ -59,11 +59,12 @@ class UploadPhotosUseCase(
         try {
             transactionRunner.run {
                 val savedPhotos: List<PhotoImage> = photoImageRepository.saveAll(photos)
+                val savedPhotoIds: List<Long> = savedPhotos.map { it.id!! }
                 if (command.folderId != null) {
-                    photoImageFolderRepository.saveAll(savedPhotos.map { it.id!! }, command.folderId)
+                    photoImageFolderRepository.saveAll(savedPhotoIds, command.folderId)
                 }
                 if (command.favorite) {
-                    favoriteImageRepository.addAll(command.userId, savedPhotos.map { it.id!! })
+                    favoriteImageRepository.addAll(command.userId, savedPhotoIds)
                 }
             }
         } catch (e: BusinessException) {

--- a/src/main/kotlin/com/neki/photo/application/usecase/UploadPhotosUseCase.kt
+++ b/src/main/kotlin/com/neki/photo/application/usecase/UploadPhotosUseCase.kt
@@ -9,6 +9,7 @@ import com.neki.photo.application.contract.MediaAvailability
 import com.neki.photo.application.port.FavoriteImageRepositoryPort
 import com.neki.photo.application.port.FolderRepositoryPort
 import com.neki.photo.application.port.MediaClientPort
+import com.neki.photo.application.port.PhotoImageFolderRepositoryPort
 import com.neki.photo.application.port.PhotoImageRepositoryPort
 import com.neki.photo.domain.entity.PhotoImage
 
@@ -22,6 +23,7 @@ import com.neki.photo.domain.entity.PhotoImage
 class UploadPhotosUseCase(
     private val mediaClient: MediaClientPort,
     private val photoImageRepository: PhotoImageRepositoryPort,
+    private val photoImageFolderRepository: PhotoImageFolderRepositoryPort,
     private val folderRepository: FolderRepositoryPort,
     private val favoriteImageRepository: FavoriteImageRepositoryPort,
 
@@ -57,6 +59,9 @@ class UploadPhotosUseCase(
         try {
             transactionRunner.run {
                 val savedPhotos: List<PhotoImage> = photoImageRepository.saveAll(photos)
+                if (command.folderId != null) {
+                    photoImageFolderRepository.saveAll(savedPhotos.map { it.id!! }, command.folderId)
+                }
                 if (command.favorite) {
                     favoriteImageRepository.addAll(command.userId, savedPhotos.map { it.id!! })
                 }

--- a/src/main/kotlin/com/neki/photo/domain/entity/PhotoImageFolder.kt
+++ b/src/main/kotlin/com/neki/photo/domain/entity/PhotoImageFolder.kt
@@ -1,0 +1,23 @@
+package com.neki.photo.domain.entity
+
+import com.neki.common.domain.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "TB_PHOTO_IMAGE_FOLDER")
+class PhotoImageFolder(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "photo_image_id", nullable = false)
+    val photoImageId: Long,
+
+    @Column(name = "folder_id", nullable = false)
+    val folderId: Long,
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/neki/photo/infra/persist/PhotoImageFolderRepositoryAdapter.kt
+++ b/src/main/kotlin/com/neki/photo/infra/persist/PhotoImageFolderRepositoryAdapter.kt
@@ -1,0 +1,32 @@
+package com.neki.photo.infra.persist
+
+import com.neki.photo.application.port.PhotoImageFolderRepositoryPort
+import com.neki.photo.domain.entity.PhotoImageFolder
+import com.neki.photo.infra.persist.jpa.JpaPhotoImageFolderRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class PhotoImageFolderRepositoryAdapter(private val jpaRepository: JpaPhotoImageFolderRepository) :
+    PhotoImageFolderRepositoryPort {
+
+    override fun saveAll(photoImageIds: List<Long>, folderId: Long) {
+        if (photoImageIds.isEmpty()) return
+        val entities = photoImageIds.map { PhotoImageFolder(photoImageId = it, folderId = folderId) }
+        jpaRepository.saveAll(entities)
+    }
+
+    override fun deleteByPhotoImageIds(photoImageIds: List<Long>) {
+        if (photoImageIds.isEmpty()) return
+        jpaRepository.deleteAllByPhotoImageIdIn(photoImageIds)
+    }
+
+    override fun deleteByFolderIds(folderIds: List<Long>) {
+        if (folderIds.isEmpty()) return
+        jpaRepository.deleteAllByFolderIdIn(folderIds)
+    }
+
+    override fun deleteByPhotoImageIdsAndFolderId(photoImageIds: List<Long>, folderId: Long) {
+        if (photoImageIds.isEmpty()) return
+        jpaRepository.deleteAllByPhotoImageIdInAndFolderId(photoImageIds, folderId)
+    }
+}

--- a/src/main/kotlin/com/neki/photo/infra/persist/PhotoImageRepositoryAdapter.kt
+++ b/src/main/kotlin/com/neki/photo/infra/persist/PhotoImageRepositoryAdapter.kt
@@ -4,6 +4,7 @@ import com.neki.common.api.dto.ResultCode
 import com.neki.common.domain.vo.SortOrder
 import com.neki.common.exception.BusinessException
 import com.neki.photo.application.contract.PhotoWithFavorite
+import com.neki.photo.application.port.PhotoImageFolderRepositoryPort
 import com.neki.photo.application.port.PhotoImageRepositoryPort
 import com.neki.photo.domain.entity.PhotoImage
 import com.neki.photo.infra.persist.jpa.JpaPhotoImageRepository
@@ -21,6 +22,7 @@ import org.springframework.stereotype.Repository
 class PhotoImageRepositoryAdapter(
     private val jpaRepository: JpaPhotoImageRepository,
     private val queryRepository: PhotoImageQueryRepository,
+    private val photoImageFolderRepository: PhotoImageFolderRepositoryPort,
 ) : PhotoImageRepositoryPort {
 
     override fun getOwnedPhotoWithFavorite(userId: Long, photoId: Long): PhotoWithFavorite? =
@@ -64,6 +66,9 @@ class PhotoImageRepositoryAdapter(
         photos.forEach { it.softDelete() }
         jpaRepository.saveAll(photos)
         jpaRepository.flush()
+
+        // 중간 테이블에서도 연관 삭제 (dual-write)
+        photoImageFolderRepository.deleteByPhotoImageIds(photoIds)
 
         return photos
     }

--- a/src/main/kotlin/com/neki/photo/infra/persist/jpa/JpaPhotoImageFolderRepository.kt
+++ b/src/main/kotlin/com/neki/photo/infra/persist/jpa/JpaPhotoImageFolderRepository.kt
@@ -1,0 +1,13 @@
+package com.neki.photo.infra.persist.jpa
+
+import com.neki.photo.domain.entity.PhotoImageFolder
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaPhotoImageFolderRepository : JpaRepository<PhotoImageFolder, Long> {
+
+    fun deleteAllByPhotoImageIdIn(photoImageIds: List<Long>)
+
+    fun deleteAllByFolderIdIn(folderIds: List<Long>)
+
+    fun deleteAllByPhotoImageIdInAndFolderId(photoImageIds: List<Long>, folderId: Long)
+}

--- a/src/main/resources/db/migration/V16__create_photo_image_folder_table.sql
+++ b/src/main/resources/db/migration/V16__create_photo_image_folder_table.sql
@@ -4,7 +4,9 @@ CREATE TABLE TB_PHOTO_IMAGE_FOLDER (
     folder_id BIGINT NOT NULL,
     created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP NOT NULL,
-    CONSTRAINT uk_photo_image_folder UNIQUE (photo_image_id, folder_id)
+    CONSTRAINT uk_photo_image_folder UNIQUE (photo_image_id, folder_id),
+    CONSTRAINT fk_photo_image_folder_photo_image FOREIGN KEY (photo_image_id) REFERENCES TB_PHOTO_IMAGE (id),
+    CONSTRAINT fk_photo_image_folder_folder FOREIGN KEY (folder_id) REFERENCES TB_FOLDER (id) ON DELETE CASCADE
 );
 
 CREATE INDEX idx_photo_image_folder_folder_id ON TB_PHOTO_IMAGE_FOLDER (folder_id);

--- a/src/main/resources/db/migration/V16__create_photo_image_folder_table.sql
+++ b/src/main/resources/db/migration/V16__create_photo_image_folder_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE TB_PHOTO_IMAGE_FOLDER (
+    id BIGSERIAL PRIMARY KEY,
+    photo_image_id BIGINT NOT NULL,
+    folder_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    CONSTRAINT uk_photo_image_folder UNIQUE (photo_image_id, folder_id)
+);
+
+CREATE INDEX idx_photo_image_folder_folder_id ON TB_PHOTO_IMAGE_FOLDER (folder_id);


### PR DESCRIPTION
## Summary

  - 사진-폴더 관계를 M:N으로 점진적 마이그레이션하기 위한 중간 테이블(TB_PHOTO_IMAGE_FOLDER) 생성
  - 무중단 배포를 위해 기존 folder_id 컬럼은 유지하면서, 모든 쓰기 작업에 Dual-Write 적용

##  Details

###  배경

현재 사진(TB_PHOTO_IMAGE)은 folder_id 컬럼으로 폴더와 1:N 관계를 가지고 있다. 향후 하나의 사진이 여러 폴더에 속할 수 있도록(M:N) 구조를 변경하려 하며, 무중단으로 진행하기 위해 Expand-Migrate-Contract 패턴을 적용

  전체 마이그레이션 로드맵

  | Phase           | 작업                                              | 브랜치  |
|-----------------|---------------------------------------------------|---------|
| 1. Expand       | 중간 테이블 생성                                  | 이번 PR |
| 2. Dual-Write   | 쓰기 시 folder_id + 중간 테이블 동시 저장         | 이번 PR |
| 3. Backfill     | 기존 folder_id 데이터를 중간 테이블로 일괄 복사   | 다음 PR |
| 4. Switch Read  | 읽기를 중간 테이블 기준으로 전환                  | 다음 PR |
| 5. Contract     | folder_id 컬럼 제거                               | 다음 PR |

  이번 PR 변경 내용

  Phase 1 — 테이블 생성
  - V16__create_photo_image_folder_table.sql: TB_PHOTO_IMAGE_FOLDER 생성
    - UNIQUE(photo_image_id, folder_id) composite unique constraint
    - folder_id 단독 인덱스 (폴더 기준 조회 성능)

  Phase 2 — Dual-Write
  - 모든 folder_id 쓰기 지점에서 중간 테이블에도 동일하게 반영
    - 사진 업로드 시 → 중간 테이블 insert
    - 폴더 삭제 시 → 중간 테이블 delete
    - 폴더에서 사진 제거 시 → 중간 테이블 delete
    - 사진 soft delete 시 → 중간 테이블 delete

  기존 동작 영향

  - 읽기는 기존 folder_id 컬럼을 그대로 사용하므로 API 동작 변화 없음
  - 롤링 업데이트 중 구버전 Pod은 folder_id에만 쓰기 → Backfill 단계에서 보정 예정

