### PR TITLE
docs/#185 issue template 및 create-issue skill 추가

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -11,6 +11,7 @@ description: Create a GitHub issue following project conventions. Use when creat
 - Feature template: !`cat .github/ISSUE_TEMPLATE/feature.yml`
 - Bug template: !`cat .github/ISSUE_TEMPLATE/bug.yml`
 - Chore template: !`cat .github/ISSUE_TEMPLATE/chore.yml`
+- Docs template: !`cat .github/ISSUE_TEMPLATE/docs.yml`
 
 ## Conventions
 

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: create-issue
+description: Create a GitHub issue following project conventions. Use when creating issues.
+---
+
+# Create Issue
+
+## Context
+
+- Available issue templates: !`ls .github/ISSUE_TEMPLATE/`
+- Feature template: !`cat .github/ISSUE_TEMPLATE/feature.yml`
+- Bug template: !`cat .github/ISSUE_TEMPLATE/bug.yml`
+- Chore template: !`cat .github/ISSUE_TEMPLATE/chore.yml`
+
+## Conventions
+
+### Issue Title
+
+Format: `{type}: 설명`
+
+| Type | 용도 | Label |
+|------|------|-------|
+| `feat` | 새로운 기능 | `enhancement` |
+| `fix` | 버그 수정 | `bug` |
+| `docs` | 문서 작업 | `documentation` |
+| `chore` | 리팩토링, 설정 등 | (none) |
+
+Examples:
+- `feat: 사진 복제 API`
+- `fix: 읽기 전환 및 folder_id 컬럼 제거`
+- `chore: GitOps 배포 파이프라인 적용`
+
+### Issue Body
+
+`.github/ISSUE_TEMPLATE/` 의 해당 type template을 읽고, template의 필드 구조에 맞춰 body를 작성한다.
+
+### Sub-issue
+
+Parent issue가 지정된 경우, issue 생성 후 parent에 sub-issue로 연결한다:
+```bash
+gh api graphql -f query='mutation { addSubIssue(input: {issueId: "{parent_node_id}", subIssueId: "{new_issue_node_id}"}) { issue { id } } }'
+```
+
+### Assignee
+
+항상 `--assignee @me`로 본인에게 할당한다.
+
+## Task
+
+1. 사용자의 요청에서 issue type을 판단한다.
+2. 해당 type의 template 파일(`.github/ISSUE_TEMPLATE/{type}.yml`)을 읽는다.
+3. Template의 필드 구조에 맞춰 issue body를 작성한다.
+4. `gh issue create`로 issue를 생성한다:
+   - `--title`: convention에 맞는 제목
+   - `--label`: type에 해당하는 label
+   - `--assignee @me`
+   - `--body`: template 기반 내용
+5. Parent issue가 있으면 sub-issue로 연결한다.
+6. 생성된 issue URL을 출력한다.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,34 @@
+name: Bug Report
+description: 버그를 제보합니다.
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: 발생한 버그를 설명해주세요.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: 버그를 재현하는 단계를 작성해주세요.
+      value: |
+        1.
+    validations:
+      required: false
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: 기대하는 동작을 설명해주세요.
+    validations:
+      required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: 참고 사항이 있다면 작성해주세요.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,19 @@
+name: Chore
+description: 리팩토링, 설정 변경 등 기술적 작업을 요청합니다.
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: 작업 내용을 설명해주세요.
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      description: 작업 항목을 체크리스트로 작성해주세요.
+      value: |
+        - [ ]
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,20 @@
+name: Documentation
+description: 문서 추가 또는 수정을 요청합니다.
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: 문서 작업 내용을 설명해주세요.
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      description: 작업 항목을 체크리스트로 작성해주세요.
+      value: |
+        - [ ]
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,27 @@
+name: Feature Request
+description: 새로운 기능을 요청합니다.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: 구현하고자 하는 기능을 설명해주세요.
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      description: 작업 항목을 체크리스트로 작성해주세요.
+      value: |
+        - [ ]
+    validations:
+      required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: 참고 사항이 있다면 작성해주세요.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Issue 생성 시 일관된 포맷을 유지하기 위해 GitHub issue template과 Claude Code skill을 추가합니다.

## Changes

- `.github/ISSUE_TEMPLATE/feature.yml` 추가 — 기능 요청 템플릿
- `.github/ISSUE_TEMPLATE/bug.yml` 추가 — 버그 리포트 템플릿
- `.github/ISSUE_TEMPLATE/chore.yml` 추가 — 기술적 작업 템플릿
- `.claude/skills/create-issue/SKILL.md` 추가 — issue template을 참조하는 Claude Code skill

## Related Issue

#185

## Notes

- Issue template이 SoT이며, skill은 런타임에 template 파일을 읽어 사용합니다
- Sub-issue 연결 기능을 포함하여 parent-child issue 관계를 지원합니다