### PR TITLE
docs/#191: 불필요한 CLAUDE.md 텍스트 제거

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -70,11 +70,9 @@ command):
 
 ### ❌ NEVER DO
 
-| Constraint                            | Reason                                             |
-|---------------------------------------|----------------------------------------------------|
-| Import from other domains             | Breaks module isolation                            |
-| Bypass ports to access infra directly | Violates Clean Architecture (exception: user) |
-| Remove observability code             | Critical for production debugging                  |
+| Constraint                | Reason                            |
+|---------------------------|-----------------------------------|
+| Remove observability code | Critical for production debugging |
 
 ### ✅ ALWAYS DO
 


### PR DESCRIPTION
## Summary
- ArchUnit 테스트 도입으로 대체된 CLAUDE.md NEVER DO 제약 조건 2개 제거
  - `Import from other domains` (도메인 격리 → ArchUnit)
  - `Bypass ports to access infra directly` (클린 아키텍처 의존방향 → ArchUnit)

closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)