### PR TITLE
docs/#192: commit skill 생성

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -63,6 +63,7 @@ command):
 | Configuration       | `/configuration`      |
 | Logging/Metrics     | `/observability`      |
 | S3 uploads/Media    | `/presigned-url-flow` |
+| Committing changes  | `/commit`             |
 
 ---
 
@@ -70,11 +71,11 @@ command):
 
 ### ❌ NEVER DO
 
-| Constraint                            | Reason                                             |
-|---------------------------------------|----------------------------------------------------|
-| Import from other domains             | Breaks module isolation                            |
+| Constraint                            | Reason                                        |
+|---------------------------------------|-----------------------------------------------|
+| Import from other domains             | Breaks module isolation                       |
 | Bypass ports to access infra directly | Violates Clean Architecture (exception: user) |
-| Remove observability code             | Critical for production debugging                  |
+| Remove observability code             | Critical for production debugging             |
 
 ### ✅ ALWAYS DO
 
@@ -118,6 +119,7 @@ Skills are auto-loaded when relevant tasks are detected, or can be invoked manua
 | `configuration`      | `/configuration`      | Environment settings, profiles, secrets           |
 | `observability`      | `/observability`      | Logging, metrics, monitoring                      |
 | `testing`            | `/testing`            | Writing tests, test coverage                      |
+| `commit`             | `/commit`             | 코드 작업 완료 후 커밋 생성                                  |
 | `presigned-url-flow` | `/presigned-url-flow` | S3 upload, media/image handling                   |
 
 ### Quick File Reference

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -116,11 +116,11 @@ Skills are auto-loaded when relevant tasks are detected, or can be invoked manua
 |----------------------|-----------------------|---------------------------------------------------|
 | `api-patterns`       | `/api-patterns`       | API endpoint development, request/response design |
 | `architecture`       | `/architecture`       | New domain/module design, Clean Architecture      |
+| `commit`             | `/commit`             | 코드 작업 완료 후 커밋 생성                                  |
 | `configuration`      | `/configuration`      | Environment settings, profiles, secrets           |
 | `observability`      | `/observability`      | Logging, metrics, monitoring                      |
-| `testing`            | `/testing`            | Writing tests, test coverage                      |
-| `commit`             | `/commit`             | 코드 작업 완료 후 커밋 생성                                  |
 | `presigned-url-flow` | `/presigned-url-flow` | S3 upload, media/image handling                   |
+| `testing`            | `/testing`            | Writing tests, test coverage                      |
 
 ### Quick File Reference
 

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -24,10 +24,10 @@ description: 프로젝트 컨벤션에 맞는 일관된 커밋 메시지를 생�
 ### 동작 흐름
 
 1. `git status`로 변경 사항 확인
-2. `git diff HEAD`로 변경 내용 분석
+2. `git diff --staged`로 스테이징된 변경 내용 분석
 3. `git log --oneline -10`으로 최근 커밋 스타일 참조
 4. 아래 컨벤션에 맞는 커밋 메시지 생성
-5. 관련 파일 staging 후 커밋 수행
+5. `git commit` 수행
 
 ---
 

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: commit
+description: 프로젝트 컨벤션에 맞는 일관된 커밋 메시지를 생성하고 커밋을 수행합니다.
+---
+
+# Commit Skill
+
+코드 작업이 완료된 후, 프로젝트 커밋 메시지 컨벤션에 맞는 커밋을 생성합니다.
+
+---
+
+## 사용법
+
+### 사용 시점
+
+코드 작업이 **완료된 후** 커밋을 생성할 때 사용합니다.
+
+### 호출 방법
+
+```
+/commit
+```
+
+### 동작 흐름
+
+1. `git status`로 변경 사항 확인
+2. `git diff HEAD`로 변경 내용 분석
+3. `git log --oneline -10`으로 최근 커밋 스타일 참조
+4. 아래 컨벤션에 맞는 커밋 메시지 생성
+5. 관련 파일 staging 후 커밋 수행
+
+---
+
+## 커밋 메시지 컨벤션
+
+### 형식
+
+```
+<type>: <한국어 설명>
+```
+
+### 허용 타입
+
+| Type       | 설명        |
+|------------|-----------|
+| `feat`     | 새로운 기능 추가 |
+| `fix`      | 버그 수정     |
+| `refactor` | 리팩토링      |
+| `test`     | 테스트 추가/수정 |
+| `chore`    | 빌드, 설정 변경 |
+| `docs`     | 문서 변경     |
+
+### 작성 규칙
+
+- 설명은 **한국어**로 작성
+- 간결하게 **무엇을 했는지** 명확히 기술
+- 메시지 끝에 Co-Authored-By 포함:
+  ```
+  Co-Authored-By: Claude <model> <noreply@anthropic.com>
+  ```
+
+### 예시
+
+```
+feat: 사진 이동 API 추가 (PATCH /api/folders/{sourceFolderId}/photos/move)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+```
+refactor: 폴더 소유권 확인을 단일 쿼리로 개선
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+## 규칙
+
+- **staged 파일만 커밋**: `.env`, credentials 등 민감 파일은 절대 staging하지 않음
+- **하나의 논리적 변경 단위**: 한 커밋에 하나의 목적만 담음
+- **spotlessApply**: hook이 자동 실행하므로 skill에서 별도 실행 불필요
+- **--amend 금지**: 항상 새로운 커밋을 생성 (hook 실패 시에도 새 커밋으로 재시도)


### PR DESCRIPTION
## Summary
- 일관된 Claude Code 커밋 메시지 생성을 위한 commit skill 추가
- `.claude/skills/commit/SKILL.md` 생성: 커밋 메시지 컨벤션, 사용법, 사용 시점 포함
- `CLAUDE.md` Skills 테이블에 commit skill 등록

closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)