### PR TITLE
Fix/#203: 사진 목록 메모 필드 추가 반환

### DIFF
--- a/src/main/kotlin/com/neki/photo/api/converter/PhotoImageResultConverter.kt
+++ b/src/main/kotlin/com/neki/photo/api/converter/PhotoImageResultConverter.kt
@@ -30,6 +30,7 @@ class PhotoImageResultConverter(private val appProperties: AppProperties) {
                 contentType = it.contentType,
                 width = it.width,
                 height = it.height,
+                memo = it.memo,
                 createdAt = it.createdAt,
             )
         },

--- a/src/main/kotlin/com/neki/photo/api/dto/PhotoImageResponse.kt
+++ b/src/main/kotlin/com/neki/photo/api/dto/PhotoImageResponse.kt
@@ -28,6 +28,8 @@ data class GetPhotosResponse(
         val width: Int? = null,
         @field:Schema(description = "이미지 높이", example = "1440", nullable = true)
         val height: Int? = null,
+        @field:Schema(description = "메모", example = "친구들이랑 함께", nullable = true)
+        val memo: String? = null,
         @field:Schema(description = "업로드 날짜", example = "2025-12-23T07:09:00")
         val createdAt: LocalDateTime,
     )

--- a/src/main/kotlin/com/neki/photo/application/result/GetPhotosResult.kt
+++ b/src/main/kotlin/com/neki/photo/application/result/GetPhotosResult.kt
@@ -19,6 +19,7 @@ data class GetPhotosResult(val photos: List<PhotoInfo>, val hasNext: Boolean) {
         val uploadMethod: UploadMethod?,
         val width: Int? = null,
         val height: Int? = null,
+        val memo: String? = null,
         val createdAt: LocalDateTime,
         val capturedAt: LocalDateTime?,
     )

--- a/src/main/kotlin/com/neki/photo/application/usecase/GetPhotosUseCase.kt
+++ b/src/main/kotlin/com/neki/photo/application/usecase/GetPhotosUseCase.kt
@@ -84,6 +84,7 @@ class GetPhotosUseCase(
                 uploadMethod = photo.uploadMethod,
                 width = media.width,
                 height = media.height,
+                memo = photo.memo,
                 createdAt = photo.createdAt!!,
                 capturedAt = photo.capturedAt,
             )


### PR DESCRIPTION
## Description
- 사진 목록 API 내 memo 필드 추가 반환
- nullable 형태로 반환
- iOS의 경우 목록으로 상세페이지 진입하고 있기 떄문에 목록에서 메모 필드 추가 반환