### PR TITLE
feat: 기존 folder_id 데이터를 중간 테이블로 Backfill

### DIFF
--- a/src/main/kotlin/com/neki/photo/api/converter/PhotoImageResultConverter.kt
+++ b/src/main/kotlin/com/neki/photo/api/converter/PhotoImageResultConverter.kt
@@ -30,6 +30,7 @@ class PhotoImageResultConverter(private val appProperties: AppProperties) {
                 contentType = it.contentType,
                 width = it.width,
                 height = it.height,
+                memo = it.memo,
                 createdAt = it.createdAt,
             )
         },

--- a/src/main/kotlin/com/neki/photo/api/converter/PhotoImageResultConverter.kt
+++ b/src/main/kotlin/com/neki/photo/api/converter/PhotoImageResultConverter.kt
@@ -43,6 +43,7 @@ class PhotoImageResultConverter(private val appProperties: AppProperties) {
         contentType = result.contentType,
         width = result.width,
         height = result.height,
+        memo = result.memo,
         createdAt = result.createdAt,
     )
 

--- a/src/main/kotlin/com/neki/photo/api/dto/PhotoImageResponse.kt
+++ b/src/main/kotlin/com/neki/photo/api/dto/PhotoImageResponse.kt
@@ -46,6 +46,8 @@ data class GetPhotoResponse(
     val width: Int? = null,
     @field:Schema(description = "이미지 높이", example = "1440", nullable = true)
     val height: Int? = null,
+    @field:Schema(description = "메모", example = "친구들이랑 함께", nullable = true)
+    val memo: String? = null,
     @field:Schema(description = "업로드 날짜", example = "2025-12-23T07:09:00")
     val createdAt: LocalDateTime,
 )

--- a/src/main/kotlin/com/neki/photo/api/dto/PhotoImageResponse.kt
+++ b/src/main/kotlin/com/neki/photo/api/dto/PhotoImageResponse.kt
@@ -28,6 +28,8 @@ data class GetPhotosResponse(
         val width: Int? = null,
         @field:Schema(description = "이미지 높이", example = "1440", nullable = true)
         val height: Int? = null,
+        @field:Schema(description = "메모", example = "친구들이랑 함께", nullable = true)
+        val memo: String? = null,
         @field:Schema(description = "업로드 날짜", example = "2025-12-23T07:09:00")
         val createdAt: LocalDateTime,
     )

--- a/src/main/kotlin/com/neki/photo/application/result/GetPhotosResult.kt
+++ b/src/main/kotlin/com/neki/photo/application/result/GetPhotosResult.kt
@@ -32,6 +32,7 @@ data class GetPhotoResult(
     val uploadMethod: UploadMethod?,
     val width: Int? = null,
     val height: Int? = null,
+    val memo: String? = null,
     val createdAt: LocalDateTime,
     val capturedAt: LocalDateTime?,
 )

--- a/src/main/kotlin/com/neki/photo/application/result/GetPhotosResult.kt
+++ b/src/main/kotlin/com/neki/photo/application/result/GetPhotosResult.kt
@@ -19,6 +19,7 @@ data class GetPhotosResult(val photos: List<PhotoInfo>, val hasNext: Boolean) {
         val uploadMethod: UploadMethod?,
         val width: Int? = null,
         val height: Int? = null,
+        val memo: String? = null,
         val createdAt: LocalDateTime,
         val capturedAt: LocalDateTime?,
     )

--- a/src/main/kotlin/com/neki/photo/application/usecase/GetPhotoUseCase.kt
+++ b/src/main/kotlin/com/neki/photo/application/usecase/GetPhotoUseCase.kt
@@ -35,6 +35,7 @@ class GetPhotoUseCase(
             uploadMethod = photo.uploadMethod,
             width = mediaInfo.width,
             height = mediaInfo.height,
+            memo = photo.memo,
             createdAt = photo.createdAt!!,
             capturedAt = photo.capturedAt,
         )

--- a/src/main/kotlin/com/neki/photo/application/usecase/GetPhotosUseCase.kt
+++ b/src/main/kotlin/com/neki/photo/application/usecase/GetPhotosUseCase.kt
@@ -84,6 +84,7 @@ class GetPhotosUseCase(
                 uploadMethod = photo.uploadMethod,
                 width = media.width,
                 height = media.height,
+                memo = photo.memo,
                 createdAt = photo.createdAt!!,
                 capturedAt = photo.capturedAt,
             )

--- a/src/main/resources/db/migration/V17__backfill_photo_image_folder.sql
+++ b/src/main/resources/db/migration/V17__backfill_photo_image_folder.sql
@@ -1,0 +1,6 @@
+INSERT INTO TB_PHOTO_IMAGE_FOLDER (photo_image_id, folder_id, created_at, updated_at)
+SELECT id, folder_id, created_at, updated_at
+FROM TB_PHOTO_IMAGE
+WHERE folder_id IS NOT NULL
+  AND deleted_at IS NULL
+ON CONFLICT (photo_image_id, folder_id) DO NOTHING;


### PR DESCRIPTION
## Description
- Expand-Migrate-Contract 패턴
- 사진-폴더 관계를 M:N으로 점진적 마이그레이션하기 위한 중간 테이블(TB_PHOTO_IMAGE_FOLDER) 생성
- 무중단 배포를 위해 기존 folder_id 컬럼은 유지하면서, 모든 쓰기 작업에 Dual-Write 적용

 | Phase           | 작업                                              | 브랜치  |
|-----------------|---------------------------------------------------|---------|
| 1. Expand       | 중간 테이블 생성                                  | 반영 완료 |
| 2. Dual-Write   | 쓰기 시 folder_id + 중간 테이블 동시 저장         | 반영 완료 |
| 3. Backfill     | 기존 folder_id 데이터를 중간 테이블로 일괄 복사   | 이번 PR |
| 4. Switch Read  | 읽기를 중간 테이블 기준으로 전환                  | 미 반영 |
| 5. Contract     | folder_id 컬럼 제거                               | 미 반영 |