### PR TITLE
test: [User] UseCase 단위 테스트 추가

### DIFF
--- a/src/test/kotlin/com/neki/user/application/usecase/DeleteMeUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/DeleteMeUseCaseTest.kt
@@ -12,38 +12,39 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 
-class DeleteMeUseCaseTest : FunSpec({
+class DeleteMeUseCaseTest :
+    FunSpec({
 
-    lateinit var userRepository: UserRepositoryPort
-    lateinit var useCase: DeleteMeUseCase
+        lateinit var userRepository: UserRepositoryPort
+        lateinit var useCase: DeleteMeUseCase
 
-    beforeTest {
-        userRepository = mockk()
-        useCase = DeleteMeUseCase(userRepository)
-    }
-
-    test("정상 탈퇴 - 유저 존재 시 withdraw 호출 확인") {
-        // Given
-        val user = aUser(id = 1L, email = "test@example.com", oid = "some-oid")
-        every { userRepository.findById(1L) } returns user
-
-        // When
-        useCase.execute(DeleteUserCommand(userId = 1L))
-
-        // Then
-        user.email shouldBe null
-        user.oid shouldBe null
-        verify(exactly = 1) { userRepository.findById(1L) }
-    }
-
-    test("미존재 유저 탈퇴 시 NOT_FOUND_USER BusinessException 발생") {
-        // Given
-        every { userRepository.findById(999L) } returns null
-
-        // When & Then
-        val exception = shouldThrow<BusinessException> {
-            useCase.execute(DeleteUserCommand(userId = 999L))
+        beforeTest {
+            userRepository = mockk()
+            useCase = DeleteMeUseCase(userRepository)
         }
-        exception.resultCode shouldBe ResultCode.NOT_FOUND_USER
-    }
-})
+
+        test("정상 탈퇴 - 유저 존재 시 withdraw 호출 확인") {
+            // Given
+            val user = aUser(id = 1L, email = "test@example.com", oid = "some-oid")
+            every { userRepository.findById(1L) } returns user
+
+            // When
+            useCase.execute(DeleteUserCommand(userId = 1L))
+
+            // Then
+            user.email shouldBe null
+            user.oid shouldBe null
+            verify(exactly = 1) { userRepository.findById(1L) }
+        }
+
+        test("미존재 유저 탈퇴 시 NOT_FOUND_USER BusinessException 발생") {
+            // Given
+            every { userRepository.findById(999L) } returns null
+
+            // When & Then
+            val exception = shouldThrow<BusinessException> {
+                useCase.execute(DeleteUserCommand(userId = 999L))
+            }
+            exception.resultCode shouldBe ResultCode.NOT_FOUND_USER
+        }
+    })

--- a/src/test/kotlin/com/neki/user/application/usecase/DeleteMeUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/DeleteMeUseCaseTest.kt
@@ -1,0 +1,49 @@
+package com.neki.user.application.usecase
+
+import com.neki.common.api.dto.ResultCode
+import com.neki.common.exception.BusinessException
+import com.neki.testfixture.aUser
+import com.neki.user.application.command.DeleteUserCommand
+import com.neki.user.application.port.UserRepositoryPort
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class DeleteMeUseCaseTest : FunSpec({
+
+    lateinit var userRepository: UserRepositoryPort
+    lateinit var useCase: DeleteMeUseCase
+
+    beforeTest {
+        userRepository = mockk()
+        useCase = DeleteMeUseCase(userRepository)
+    }
+
+    test("정상 탈퇴 - 유저 존재 시 withdraw 호출 확인") {
+        // Given
+        val user = aUser(id = 1L, email = "test@example.com", oid = "some-oid")
+        every { userRepository.findById(1L) } returns user
+
+        // When
+        useCase.execute(DeleteUserCommand(userId = 1L))
+
+        // Then
+        user.email shouldBe null
+        user.oid shouldBe null
+        verify(exactly = 1) { userRepository.findById(1L) }
+    }
+
+    test("미존재 유저 탈퇴 시 NOT_FOUND_USER BusinessException 발생") {
+        // Given
+        every { userRepository.findById(999L) } returns null
+
+        // When & Then
+        val exception = shouldThrow<BusinessException> {
+            useCase.execute(DeleteUserCommand(userId = 999L))
+        }
+        exception.resultCode shouldBe ResultCode.NOT_FOUND_USER
+    }
+})

--- a/src/test/kotlin/com/neki/user/application/usecase/DeleteMeUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/DeleteMeUseCaseTest.kt
@@ -6,45 +6,51 @@ import com.neki.testfixture.aUser
 import com.neki.user.application.command.DeleteUserCommand
 import com.neki.user.application.port.UserRepositoryPort
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-class DeleteMeUseCaseTest :
-    FunSpec({
+class DeleteMeUseCaseTest {
 
-        lateinit var userRepository: UserRepositoryPort
-        lateinit var useCase: DeleteMeUseCase
+    lateinit var userRepository: UserRepositoryPort
+    lateinit var useCase: DeleteMeUseCase
 
-        beforeTest {
-            userRepository = mockk()
-            useCase = DeleteMeUseCase(userRepository)
+    @BeforeEach
+    fun setUp() {
+        userRepository = mockk()
+        useCase = DeleteMeUseCase(userRepository)
+    }
+
+    @Test
+    @DisplayName("정상 탈퇴 - 유저 존재 시 withdraw 호출 확인")
+    fun `정상 탈퇴 - 유저 존재 시 withdraw 호출 확인`() {
+        // Given
+        val user = aUser(id = 1L, email = "test@example.com", oid = "some-oid")
+        every { userRepository.findById(1L) } returns user
+
+        // When
+        useCase.execute(DeleteUserCommand(userId = 1L))
+
+        // Then
+        user.email shouldBe null
+        user.oid shouldBe null
+        verify(exactly = 1) { userRepository.findById(1L) }
+    }
+
+    @Test
+    @DisplayName("미존재 유저 탈퇴 시 NOT_FOUND_USER BusinessException 발생")
+    fun `미존재 유저 탈퇴 시 NOT_FOUND_USER BusinessException 발생`() {
+        // Given
+        every { userRepository.findById(999L) } returns null
+
+        // When & Then
+        val exception = shouldThrow<BusinessException> {
+            useCase.execute(DeleteUserCommand(userId = 999L))
         }
-
-        test("정상 탈퇴 - 유저 존재 시 withdraw 호출 확인") {
-            // Given
-            val user = aUser(id = 1L, email = "test@example.com", oid = "some-oid")
-            every { userRepository.findById(1L) } returns user
-
-            // When
-            useCase.execute(DeleteUserCommand(userId = 1L))
-
-            // Then
-            user.email shouldBe null
-            user.oid shouldBe null
-            verify(exactly = 1) { userRepository.findById(1L) }
-        }
-
-        test("미존재 유저 탈퇴 시 NOT_FOUND_USER BusinessException 발생") {
-            // Given
-            every { userRepository.findById(999L) } returns null
-
-            // When & Then
-            val exception = shouldThrow<BusinessException> {
-                useCase.execute(DeleteUserCommand(userId = 999L))
-            }
-            exception.resultCode shouldBe ResultCode.NOT_FOUND_USER
-        }
-    })
+        exception.resultCode shouldBe ResultCode.NOT_FOUND_USER
+    }
+}

--- a/src/test/kotlin/com/neki/user/application/usecase/GetUserInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/GetUserInfoUseCaseTest.kt
@@ -38,7 +38,7 @@ class GetUserInfoUseCaseTest {
 
     @Test
     @DisplayName("정상 조회 - 프로필 이미지 있음: user, storageKey, terms 동의 여부 반환")
-    fun `정상 조회 - 프로필 이미지 있음: user, storageKey, terms 동의 여부 반환`() {
+    fun `정상 조회 - 프로필 이미지 있음 user, storageKey, terms 동의 여부 반환`() {
         // Given
         val userId = 1L
         val mediaId = 10L

--- a/src/test/kotlin/com/neki/user/application/usecase/GetUserInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/GetUserInfoUseCaseTest.kt
@@ -1,0 +1,119 @@
+package com.neki.user.application.usecase
+
+import com.neki.common.api.dto.ResultCode
+import com.neki.common.exception.BusinessException
+import com.neki.testfixture.aUser
+import com.neki.user.application.command.GetUserCommand
+import com.neki.user.application.port.MediaClientPort
+import com.neki.user.application.port.TermClientPort
+import com.neki.user.application.port.UserRepositoryPort
+import com.neki.user.domain.enums.ProviderType
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class GetUserInfoUseCaseTest : FunSpec({
+
+    lateinit var userRepository: UserRepositoryPort
+    lateinit var mediaClient: MediaClientPort
+    lateinit var termClient: TermClientPort
+    lateinit var useCase: GetUserInfoUseCase
+
+    beforeTest {
+        userRepository = mockk()
+        mediaClient = mockk()
+        termClient = mockk()
+        useCase = GetUserInfoUseCase(
+            userRepository = userRepository,
+            mediaClient = mediaClient,
+            termClient = termClient,
+        )
+    }
+
+    test("정상 조회 - 프로필 이미지 있음: user, storageKey, terms 동의 여부 반환") {
+        // Given
+        val userId = 1L
+        val mediaId = 10L
+        val user = aUser(id = userId, name = "테스트유저", email = "test@example.com", profileImageId = mediaId, providerType = ProviderType.KAKAO)
+
+        every { userRepository.findById(userId) } returns user
+        every { mediaClient.getStorageKey(ownerId = userId, mediaId = mediaId) } returns "profile/image.jpg"
+        every { termClient.hasAgreedToLatestTerms(userId) } returns true
+
+        // When
+        val result = useCase.execute(GetUserCommand(userId = userId))
+
+        // Then
+        result.userId shouldBe userId
+        result.name shouldBe "테스트유저"
+        result.email shouldBe "test@example.com"
+        result.objectKey shouldBe "profile/image.jpg"
+        result.providerType shouldBe ProviderType.KAKAO
+        result.agreeTerms shouldBe true
+    }
+
+    test("프로필 이미지 없음 - storageKey null 반환") {
+        // Given
+        val userId = 1L
+        val user = aUser(id = userId, name = "테스트유저", profileImageId = null, providerType = ProviderType.KAKAO)
+
+        every { userRepository.findById(userId) } returns user
+        every { termClient.hasAgreedToLatestTerms(userId) } returns false
+
+        // When
+        val result = useCase.execute(GetUserCommand(userId = userId))
+
+        // Then
+        result.objectKey shouldBe null
+        verify(exactly = 0) { mediaClient.getStorageKey(any(), any()) }
+    }
+
+    test("유저 미존재 시 NOT_FOUND_USER BusinessException 발생") {
+        // Given
+        every { userRepository.findById(999L) } returns null
+
+        // When & Then
+        val exception = shouldThrow<BusinessException> {
+            useCase.execute(GetUserCommand(userId = 999L))
+        }
+        exception.resultCode shouldBe ResultCode.NOT_FOUND_USER
+        verify(exactly = 0) { mediaClient.getStorageKey(any(), any()) }
+        verify(exactly = 0) { termClient.hasAgreedToLatestTerms(any()) }
+    }
+
+    test("mediaClient 예외 - 프로필 이미지 조회 실패 시 전체 요청 실패") {
+        // Given
+        val userId = 1L
+        val mediaId = 10L
+        val user = aUser(id = userId, profileImageId = mediaId)
+
+        every { userRepository.findById(userId) } returns user
+        every {
+            mediaClient.getStorageKey(ownerId = userId, mediaId = mediaId)
+        } throws RuntimeException("미디어 조회 실패")
+
+        // When & Then
+        shouldThrow<RuntimeException> {
+            useCase.execute(GetUserCommand(userId = userId))
+        }
+    }
+
+    test("termClient 예외 - 약관 동의 조회 실패 시 전체 요청 실패") {
+        // Given
+        val userId = 1L
+        val user = aUser(id = userId, profileImageId = null)
+
+        every { userRepository.findById(userId) } returns user
+        every {
+            termClient.hasAgreedToLatestTerms(userId)
+        } throws RuntimeException("약관 서비스 오류")
+
+        // When & Then
+        shouldThrow<RuntimeException> {
+            useCase.execute(GetUserCommand(userId = userId))
+        }
+    }
+})

--- a/src/test/kotlin/com/neki/user/application/usecase/GetUserInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/GetUserInfoUseCaseTest.kt
@@ -15,105 +15,113 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 
-class GetUserInfoUseCaseTest : FunSpec({
+class GetUserInfoUseCaseTest :
+    FunSpec({
 
-    lateinit var userRepository: UserRepositoryPort
-    lateinit var mediaClient: MediaClientPort
-    lateinit var termClient: TermClientPort
-    lateinit var useCase: GetUserInfoUseCase
+        lateinit var userRepository: UserRepositoryPort
+        lateinit var mediaClient: MediaClientPort
+        lateinit var termClient: TermClientPort
+        lateinit var useCase: GetUserInfoUseCase
 
-    beforeTest {
-        userRepository = mockk()
-        mediaClient = mockk()
-        termClient = mockk()
-        useCase = GetUserInfoUseCase(
-            userRepository = userRepository,
-            mediaClient = mediaClient,
-            termClient = termClient,
-        )
-    }
-
-    test("정상 조회 - 프로필 이미지 있음: user, storageKey, terms 동의 여부 반환") {
-        // Given
-        val userId = 1L
-        val mediaId = 10L
-        val user = aUser(id = userId, name = "테스트유저", email = "test@example.com", profileImageId = mediaId, providerType = ProviderType.KAKAO)
-
-        every { userRepository.findById(userId) } returns user
-        every { mediaClient.getStorageKey(ownerId = userId, mediaId = mediaId) } returns "profile/image.jpg"
-        every { termClient.hasAgreedToLatestTerms(userId) } returns true
-
-        // When
-        val result = useCase.execute(GetUserCommand(userId = userId))
-
-        // Then
-        result.userId shouldBe userId
-        result.name shouldBe "테스트유저"
-        result.email shouldBe "test@example.com"
-        result.objectKey shouldBe "profile/image.jpg"
-        result.providerType shouldBe ProviderType.KAKAO
-        result.agreeTerms shouldBe true
-    }
-
-    test("프로필 이미지 없음 - storageKey null 반환") {
-        // Given
-        val userId = 1L
-        val user = aUser(id = userId, name = "테스트유저", profileImageId = null, providerType = ProviderType.KAKAO)
-
-        every { userRepository.findById(userId) } returns user
-        every { termClient.hasAgreedToLatestTerms(userId) } returns false
-
-        // When
-        val result = useCase.execute(GetUserCommand(userId = userId))
-
-        // Then
-        result.objectKey shouldBe null
-        verify(exactly = 0) { mediaClient.getStorageKey(any(), any()) }
-    }
-
-    test("유저 미존재 시 NOT_FOUND_USER BusinessException 발생") {
-        // Given
-        every { userRepository.findById(999L) } returns null
-
-        // When & Then
-        val exception = shouldThrow<BusinessException> {
-            useCase.execute(GetUserCommand(userId = 999L))
+        beforeTest {
+            userRepository = mockk()
+            mediaClient = mockk()
+            termClient = mockk()
+            useCase = GetUserInfoUseCase(
+                userRepository = userRepository,
+                mediaClient = mediaClient,
+                termClient = termClient,
+            )
         }
-        exception.resultCode shouldBe ResultCode.NOT_FOUND_USER
-        verify(exactly = 0) { mediaClient.getStorageKey(any(), any()) }
-        verify(exactly = 0) { termClient.hasAgreedToLatestTerms(any()) }
-    }
 
-    test("mediaClient 예외 - 프로필 이미지 조회 실패 시 전체 요청 실패") {
-        // Given
-        val userId = 1L
-        val mediaId = 10L
-        val user = aUser(id = userId, profileImageId = mediaId)
+        test("정상 조회 - 프로필 이미지 있음: user, storageKey, terms 동의 여부 반환") {
+            // Given
+            val userId = 1L
+            val mediaId = 10L
+            val user =
+                aUser(
+                    id = userId,
+                    name = "테스트유저",
+                    email = "test@example.com",
+                    profileImageId = mediaId,
+                    providerType = ProviderType.KAKAO,
+                )
 
-        every { userRepository.findById(userId) } returns user
-        every {
-            mediaClient.getStorageKey(ownerId = userId, mediaId = mediaId)
-        } throws RuntimeException("미디어 조회 실패")
+            every { userRepository.findById(userId) } returns user
+            every { mediaClient.getStorageKey(ownerId = userId, mediaId = mediaId) } returns "profile/image.jpg"
+            every { termClient.hasAgreedToLatestTerms(userId) } returns true
 
-        // When & Then
-        shouldThrow<RuntimeException> {
-            useCase.execute(GetUserCommand(userId = userId))
+            // When
+            val result = useCase.execute(GetUserCommand(userId = userId))
+
+            // Then
+            result.userId shouldBe userId
+            result.name shouldBe "테스트유저"
+            result.email shouldBe "test@example.com"
+            result.objectKey shouldBe "profile/image.jpg"
+            result.providerType shouldBe ProviderType.KAKAO
+            result.agreeTerms shouldBe true
         }
-    }
 
-    test("termClient 예외 - 약관 동의 조회 실패 시 전체 요청 실패") {
-        // Given
-        val userId = 1L
-        val user = aUser(id = userId, profileImageId = null)
+        test("프로필 이미지 없음 - storageKey null 반환") {
+            // Given
+            val userId = 1L
+            val user = aUser(id = userId, name = "테스트유저", profileImageId = null, providerType = ProviderType.KAKAO)
 
-        every { userRepository.findById(userId) } returns user
-        every {
-            termClient.hasAgreedToLatestTerms(userId)
-        } throws RuntimeException("약관 서비스 오류")
+            every { userRepository.findById(userId) } returns user
+            every { termClient.hasAgreedToLatestTerms(userId) } returns false
 
-        // When & Then
-        shouldThrow<RuntimeException> {
-            useCase.execute(GetUserCommand(userId = userId))
+            // When
+            val result = useCase.execute(GetUserCommand(userId = userId))
+
+            // Then
+            result.objectKey shouldBe null
+            verify(exactly = 0) { mediaClient.getStorageKey(any(), any()) }
         }
-    }
-})
+
+        test("유저 미존재 시 NOT_FOUND_USER BusinessException 발생") {
+            // Given
+            every { userRepository.findById(999L) } returns null
+
+            // When & Then
+            val exception = shouldThrow<BusinessException> {
+                useCase.execute(GetUserCommand(userId = 999L))
+            }
+            exception.resultCode shouldBe ResultCode.NOT_FOUND_USER
+            verify(exactly = 0) { mediaClient.getStorageKey(any(), any()) }
+            verify(exactly = 0) { termClient.hasAgreedToLatestTerms(any()) }
+        }
+
+        test("mediaClient 예외 - 프로필 이미지 조회 실패 시 전체 요청 실패") {
+            // Given
+            val userId = 1L
+            val mediaId = 10L
+            val user = aUser(id = userId, profileImageId = mediaId)
+
+            every { userRepository.findById(userId) } returns user
+            every {
+                mediaClient.getStorageKey(ownerId = userId, mediaId = mediaId)
+            } throws RuntimeException("미디어 조회 실패")
+
+            // When & Then
+            shouldThrow<RuntimeException> {
+                useCase.execute(GetUserCommand(userId = userId))
+            }
+        }
+
+        test("termClient 예외 - 약관 동의 조회 실패 시 전체 요청 실패") {
+            // Given
+            val userId = 1L
+            val user = aUser(id = userId, profileImageId = null)
+
+            every { userRepository.findById(userId) } returns user
+            every {
+                termClient.hasAgreedToLatestTerms(userId)
+            } throws RuntimeException("약관 서비스 오류")
+
+            // When & Then
+            shouldThrow<RuntimeException> {
+                useCase.execute(GetUserCommand(userId = userId))
+            }
+        }
+    })

--- a/src/test/kotlin/com/neki/user/application/usecase/GetUserInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/GetUserInfoUseCaseTest.kt
@@ -9,119 +9,131 @@ import com.neki.user.application.port.TermClientPort
 import com.neki.user.application.port.UserRepositoryPort
 import com.neki.user.domain.enums.ProviderType
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-class GetUserInfoUseCaseTest :
-    FunSpec({
+class GetUserInfoUseCaseTest {
 
-        lateinit var userRepository: UserRepositoryPort
-        lateinit var mediaClient: MediaClientPort
-        lateinit var termClient: TermClientPort
-        lateinit var useCase: GetUserInfoUseCase
+    lateinit var userRepository: UserRepositoryPort
+    lateinit var mediaClient: MediaClientPort
+    lateinit var termClient: TermClientPort
+    lateinit var useCase: GetUserInfoUseCase
 
-        beforeTest {
-            userRepository = mockk()
-            mediaClient = mockk()
-            termClient = mockk()
-            useCase = GetUserInfoUseCase(
-                userRepository = userRepository,
-                mediaClient = mediaClient,
-                termClient = termClient,
+    @BeforeEach
+    fun setUp() {
+        userRepository = mockk()
+        mediaClient = mockk()
+        termClient = mockk()
+        useCase = GetUserInfoUseCase(
+            userRepository = userRepository,
+            mediaClient = mediaClient,
+            termClient = termClient,
+        )
+    }
+
+    @Test
+    @DisplayName("정상 조회 - 프로필 이미지 있음: user, storageKey, terms 동의 여부 반환")
+    fun `정상 조회 - 프로필 이미지 있음: user, storageKey, terms 동의 여부 반환`() {
+        // Given
+        val userId = 1L
+        val mediaId = 10L
+        val user =
+            aUser(
+                id = userId,
+                name = "테스트유저",
+                email = "test@example.com",
+                profileImageId = mediaId,
+                providerType = ProviderType.KAKAO,
             )
+
+        every { userRepository.findById(userId) } returns user
+        every { mediaClient.getStorageKey(ownerId = userId, mediaId = mediaId) } returns "profile/image.jpg"
+        every { termClient.hasAgreedToLatestTerms(userId) } returns true
+
+        // When
+        val result = useCase.execute(GetUserCommand(userId = userId))
+
+        // Then
+        result.userId shouldBe userId
+        result.name shouldBe "테스트유저"
+        result.email shouldBe "test@example.com"
+        result.objectKey shouldBe "profile/image.jpg"
+        result.providerType shouldBe ProviderType.KAKAO
+        result.agreeTerms shouldBe true
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 없음 - storageKey null 반환")
+    fun `프로필 이미지 없음 - storageKey null 반환`() {
+        // Given
+        val userId = 1L
+        val user = aUser(id = userId, name = "테스트유저", profileImageId = null, providerType = ProviderType.KAKAO)
+
+        every { userRepository.findById(userId) } returns user
+        every { termClient.hasAgreedToLatestTerms(userId) } returns false
+
+        // When
+        val result = useCase.execute(GetUserCommand(userId = userId))
+
+        // Then
+        result.objectKey shouldBe null
+        verify(exactly = 0) { mediaClient.getStorageKey(any(), any()) }
+    }
+
+    @Test
+    @DisplayName("유저 미존재 시 NOT_FOUND_USER BusinessException 발생")
+    fun `유저 미존재 시 NOT_FOUND_USER BusinessException 발생`() {
+        // Given
+        every { userRepository.findById(999L) } returns null
+
+        // When & Then
+        val exception = shouldThrow<BusinessException> {
+            useCase.execute(GetUserCommand(userId = 999L))
         }
+        exception.resultCode shouldBe ResultCode.NOT_FOUND_USER
+        verify(exactly = 0) { mediaClient.getStorageKey(any(), any()) }
+        verify(exactly = 0) { termClient.hasAgreedToLatestTerms(any()) }
+    }
 
-        test("정상 조회 - 프로필 이미지 있음: user, storageKey, terms 동의 여부 반환") {
-            // Given
-            val userId = 1L
-            val mediaId = 10L
-            val user =
-                aUser(
-                    id = userId,
-                    name = "테스트유저",
-                    email = "test@example.com",
-                    profileImageId = mediaId,
-                    providerType = ProviderType.KAKAO,
-                )
+    @Test
+    @DisplayName("mediaClient 예외 - 프로필 이미지 조회 실패 시 전체 요청 실패")
+    fun `mediaClient 예외 - 프로필 이미지 조회 실패 시 전체 요청 실패`() {
+        // Given
+        val userId = 1L
+        val mediaId = 10L
+        val user = aUser(id = userId, profileImageId = mediaId)
 
-            every { userRepository.findById(userId) } returns user
-            every { mediaClient.getStorageKey(ownerId = userId, mediaId = mediaId) } returns "profile/image.jpg"
-            every { termClient.hasAgreedToLatestTerms(userId) } returns true
+        every { userRepository.findById(userId) } returns user
+        every {
+            mediaClient.getStorageKey(ownerId = userId, mediaId = mediaId)
+        } throws RuntimeException("미디어 조회 실패")
 
-            // When
-            val result = useCase.execute(GetUserCommand(userId = userId))
-
-            // Then
-            result.userId shouldBe userId
-            result.name shouldBe "테스트유저"
-            result.email shouldBe "test@example.com"
-            result.objectKey shouldBe "profile/image.jpg"
-            result.providerType shouldBe ProviderType.KAKAO
-            result.agreeTerms shouldBe true
+        // When & Then
+        shouldThrow<RuntimeException> {
+            useCase.execute(GetUserCommand(userId = userId))
         }
+    }
 
-        test("프로필 이미지 없음 - storageKey null 반환") {
-            // Given
-            val userId = 1L
-            val user = aUser(id = userId, name = "테스트유저", profileImageId = null, providerType = ProviderType.KAKAO)
+    @Test
+    @DisplayName("termClient 예외 - 약관 동의 조회 실패 시 전체 요청 실패")
+    fun `termClient 예외 - 약관 동의 조회 실패 시 전체 요청 실패`() {
+        // Given
+        val userId = 1L
+        val user = aUser(id = userId, profileImageId = null)
 
-            every { userRepository.findById(userId) } returns user
-            every { termClient.hasAgreedToLatestTerms(userId) } returns false
+        every { userRepository.findById(userId) } returns user
+        every {
+            termClient.hasAgreedToLatestTerms(userId)
+        } throws RuntimeException("약관 서비스 오류")
 
-            // When
-            val result = useCase.execute(GetUserCommand(userId = userId))
-
-            // Then
-            result.objectKey shouldBe null
-            verify(exactly = 0) { mediaClient.getStorageKey(any(), any()) }
+        // When & Then
+        shouldThrow<RuntimeException> {
+            useCase.execute(GetUserCommand(userId = userId))
         }
-
-        test("유저 미존재 시 NOT_FOUND_USER BusinessException 발생") {
-            // Given
-            every { userRepository.findById(999L) } returns null
-
-            // When & Then
-            val exception = shouldThrow<BusinessException> {
-                useCase.execute(GetUserCommand(userId = 999L))
-            }
-            exception.resultCode shouldBe ResultCode.NOT_FOUND_USER
-            verify(exactly = 0) { mediaClient.getStorageKey(any(), any()) }
-            verify(exactly = 0) { termClient.hasAgreedToLatestTerms(any()) }
-        }
-
-        test("mediaClient 예외 - 프로필 이미지 조회 실패 시 전체 요청 실패") {
-            // Given
-            val userId = 1L
-            val mediaId = 10L
-            val user = aUser(id = userId, profileImageId = mediaId)
-
-            every { userRepository.findById(userId) } returns user
-            every {
-                mediaClient.getStorageKey(ownerId = userId, mediaId = mediaId)
-            } throws RuntimeException("미디어 조회 실패")
-
-            // When & Then
-            shouldThrow<RuntimeException> {
-                useCase.execute(GetUserCommand(userId = userId))
-            }
-        }
-
-        test("termClient 예외 - 약관 동의 조회 실패 시 전체 요청 실패") {
-            // Given
-            val userId = 1L
-            val user = aUser(id = userId, profileImageId = null)
-
-            every { userRepository.findById(userId) } returns user
-            every {
-                termClient.hasAgreedToLatestTerms(userId)
-            } throws RuntimeException("약관 서비스 오류")
-
-            // When & Then
-            shouldThrow<RuntimeException> {
-                useCase.execute(GetUserCommand(userId = userId))
-            }
-        }
-    })
+    }
+}

--- a/src/test/kotlin/com/neki/user/application/usecase/OauthLoginUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/OauthLoginUseCaseTest.kt
@@ -15,260 +15,272 @@ import com.neki.user.domain.enums.ProviderType
 import com.neki.user.domain.enums.RoleType
 import com.neki.user.infra.security.config.OauthProperties
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 import org.springframework.web.client.RestClient
 
-class OauthLoginUseCaseTest :
-    FunSpec({
+class OauthLoginUseCaseTest {
 
-        lateinit var oauthProperties: OauthProperties
-        lateinit var oidcTokenValidatorPort: OidcTokenValidatorPort
-        lateinit var restClient: RestClient
-        lateinit var tokenProviderPort: AuthTokenProviderPort
-        lateinit var userRepositoryPort: UserRepositoryPort
-        lateinit var nicknameGenerator: NicknameGeneratorPort
-        lateinit var transactionRunner: FakeTransactionRunner
-        lateinit var useCase: OauthLoginUseCase
+    lateinit var oauthProperties: OauthProperties
+    lateinit var oidcTokenValidatorPort: OidcTokenValidatorPort
+    lateinit var restClient: RestClient
+    lateinit var tokenProviderPort: AuthTokenProviderPort
+    lateinit var userRepositoryPort: UserRepositoryPort
+    lateinit var nicknameGenerator: NicknameGeneratorPort
+    lateinit var transactionRunner: FakeTransactionRunner
+    lateinit var useCase: OauthLoginUseCase
 
-        beforeTest {
-            oauthProperties = OauthProperties()
-            oidcTokenValidatorPort = mockk()
-            restClient = mockk()
-            tokenProviderPort = mockk()
-            userRepositoryPort = mockk()
-            nicknameGenerator = mockk()
-            transactionRunner = FakeTransactionRunner()
+    @BeforeEach
+    fun setUp() {
+        oauthProperties = OauthProperties()
+        oidcTokenValidatorPort = mockk()
+        restClient = mockk()
+        tokenProviderPort = mockk()
+        userRepositoryPort = mockk()
+        nicknameGenerator = mockk()
+        transactionRunner = FakeTransactionRunner()
 
-            useCase = OauthLoginUseCase(
-                oauthProperties = oauthProperties,
-                oidcTokenValidatorPort = oidcTokenValidatorPort,
-                restClient = restClient,
-                tokenProviderPort = tokenProviderPort,
-                userRepositoryPort = userRepositoryPort,
-                nicknameGenerator = nicknameGenerator,
-                transactionRunner = transactionRunner,
-            )
-        }
+        useCase = OauthLoginUseCase(
+            oauthProperties = oauthProperties,
+            oidcTokenValidatorPort = oidcTokenValidatorPort,
+            restClient = restClient,
+            tokenProviderPort = tokenProviderPort,
+            userRepositoryPort = userRepositoryPort,
+            nicknameGenerator = nicknameGenerator,
+            transactionRunner = transactionRunner,
+        )
+    }
 
-        test("기존 유저 로그인 - ID token 검증 후 유저 조회 및 토큰 생성") {
-            // Given
-            val idToken = "valid-id-token"
-            val existingUser =
-                aUser(id = 1L, name = "기존유저", roles = RoleType.USER.role, providerType = ProviderType.KAKAO)
-            val oauthInfoPayload = OauthInfoPayload(
-                providerType = ProviderType.KAKAO,
-                oid = "kakao-oid-123",
-                email = "existing@example.com",
+    @Test
+    @DisplayName("기존 유저 로그인 - ID token 검증 후 유저 조회 및 토큰 생성")
+    fun `기존 유저 로그인 - ID token 검증 후 유저 조회 및 토큰 생성`() {
+        // Given
+        val idToken = "valid-id-token"
+        val existingUser =
+            aUser(id = 1L, name = "기존유저", roles = RoleType.USER.role, providerType = ProviderType.KAKAO)
+        val oauthInfoPayload = OauthInfoPayload(
+            providerType = ProviderType.KAKAO,
+            oid = "kakao-oid-123",
+            email = "existing@example.com",
+            name = "기존유저",
+            imageUrl = null,
+        )
+        val command = RegisterOauthUserCommand(
+            idToken = idToken,
+            providerType = ProviderType.KAKAO,
+            platform = Platform.IOS,
+        )
+
+        every {
+            oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
+        } returns oauthInfoPayload
+        every {
+            userRepositoryPort.findByOid(oid = "kakao-oid-123", provider = ProviderType.KAKAO)
+        } returns existingUser
+        every {
+            tokenProviderPort.createAccessToken(
+                id = "1",
+                roles = listOf(RoleType.USER.role),
                 name = "기존유저",
-                imageUrl = null,
-            )
-            val command = RegisterOauthUserCommand(
-                idToken = idToken,
                 providerType = ProviderType.KAKAO,
-                platform = Platform.IOS,
             )
-
-            every {
-                oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
-            } returns oauthInfoPayload
-            every {
-                userRepositoryPort.findByOid(oid = "kakao-oid-123", provider = ProviderType.KAKAO)
-            } returns existingUser
-            every {
-                tokenProviderPort.createAccessToken(
-                    id = "1",
-                    roles = listOf(RoleType.USER.role),
-                    name = "기존유저",
-                    providerType = ProviderType.KAKAO,
-                )
-            } returns "access-token"
-            every {
-                tokenProviderPort.createRefreshToken(
-                    id = "1",
-                    roles = listOf(RoleType.USER.role),
-                    name = "기존유저",
-                    providerType = ProviderType.KAKAO,
-                )
-            } returns "refresh-token"
-
-            // When
-            val result = useCase.execute(command)
-
-            // Then
-            result.accessToken shouldBe "access-token"
-            result.refreshToken shouldBe "refresh-token"
-            verify(exactly = 0) { nicknameGenerator.generateUniqueNickname() }
-            verify(exactly = 0) { userRepositoryPort.save(any()) }
-        }
-
-        test("신규 유저 가입 - 미존재 유저 감지 후 닉네임 생성 및 저장 후 토큰 생성") {
-            // Given
-            val idToken = "valid-id-token"
-            val oauthInfoPayload = OauthInfoPayload(
+        } returns "access-token"
+        every {
+            tokenProviderPort.createRefreshToken(
+                id = "1",
+                roles = listOf(RoleType.USER.role),
+                name = "기존유저",
                 providerType = ProviderType.KAKAO,
-                oid = "kakao-oid-new",
-                email = "new@example.com",
-                name = null,
-                imageUrl = null,
             )
-            val command = RegisterOauthUserCommand(
-                idToken = idToken,
+        } returns "refresh-token"
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.accessToken shouldBe "access-token"
+        result.refreshToken shouldBe "refresh-token"
+        verify(exactly = 0) { nicknameGenerator.generateUniqueNickname() }
+        verify(exactly = 0) { userRepositoryPort.save(any()) }
+    }
+
+    @Test
+    @DisplayName("신규 유저 가입 - 미존재 유저 감지 후 닉네임 생성 및 저장 후 토큰 생성")
+    fun `신규 유저 가입 - 미존재 유저 감지 후 닉네임 생성 및 저장 후 토큰 생성`() {
+        // Given
+        val idToken = "valid-id-token"
+        val oauthInfoPayload = OauthInfoPayload(
+            providerType = ProviderType.KAKAO,
+            oid = "kakao-oid-new",
+            email = "new@example.com",
+            name = null,
+            imageUrl = null,
+        )
+        val command = RegisterOauthUserCommand(
+            idToken = idToken,
+            providerType = ProviderType.KAKAO,
+            platform = Platform.IOS,
+        )
+        val savedUser =
+            aUser(id = 2L, name = "랜덤닉네임", roles = RoleType.USER.role, providerType = ProviderType.KAKAO)
+
+        every {
+            oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
+        } returns oauthInfoPayload
+        every {
+            userRepositoryPort.findByOid(oid = "kakao-oid-new", provider = ProviderType.KAKAO)
+        } returns null
+        every { nicknameGenerator.generateUniqueNickname() } returns "랜덤닉네임"
+        every { userRepositoryPort.save(any<User>()) } returns savedUser
+        every {
+            tokenProviderPort.createAccessToken(
+                id = "2",
+                roles = listOf(RoleType.USER.role),
+                name = "랜덤닉네임",
                 providerType = ProviderType.KAKAO,
-                platform = Platform.IOS,
             )
-            val savedUser =
-                aUser(id = 2L, name = "랜덤닉네임", roles = RoleType.USER.role, providerType = ProviderType.KAKAO)
-
-            every {
-                oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
-            } returns oauthInfoPayload
-            every {
-                userRepositoryPort.findByOid(oid = "kakao-oid-new", provider = ProviderType.KAKAO)
-            } returns null
-            every { nicknameGenerator.generateUniqueNickname() } returns "랜덤닉네임"
-            every { userRepositoryPort.save(any<User>()) } returns savedUser
-            every {
-                tokenProviderPort.createAccessToken(
-                    id = "2",
-                    roles = listOf(RoleType.USER.role),
-                    name = "랜덤닉네임",
-                    providerType = ProviderType.KAKAO,
-                )
-            } returns "new-access-token"
-            every {
-                tokenProviderPort.createRefreshToken(
-                    id = "2",
-                    roles = listOf(RoleType.USER.role),
-                    name = "랜덤닉네임",
-                    providerType = ProviderType.KAKAO,
-                )
-            } returns "new-refresh-token"
-
-            // When
-            val result = useCase.execute(command)
-
-            // Then
-            result.accessToken shouldBe "new-access-token"
-            result.refreshToken shouldBe "new-refresh-token"
-            verify(exactly = 1) { nicknameGenerator.generateUniqueNickname() }
-            verify(exactly = 1) { userRepositoryPort.save(any()) }
-        }
-
-        test("ID token 검증 실패 - oidcTokenValidatorPort 예외 전파 확인") {
-            // Given
-            val idToken = "invalid-id-token"
-            val command = RegisterOauthUserCommand(
-                idToken = idToken,
+        } returns "new-access-token"
+        every {
+            tokenProviderPort.createRefreshToken(
+                id = "2",
+                roles = listOf(RoleType.USER.role),
+                name = "랜덤닉네임",
                 providerType = ProviderType.KAKAO,
-                platform = Platform.IOS,
             )
+        } returns "new-refresh-token"
 
-            every {
-                oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
-            } throws BusinessException(com.neki.common.api.dto.ResultCode.INVALID_TOKEN_ERROR)
+        // When
+        val result = useCase.execute(command)
 
-            // When & Then
-            shouldThrow<BusinessException> {
-                useCase.execute(command)
-            }
-            verify(exactly = 0) { userRepositoryPort.findByOid(any(), any()) }
-        }
+        // Then
+        result.accessToken shouldBe "new-access-token"
+        result.refreshToken shouldBe "new-refresh-token"
+        verify(exactly = 1) { nicknameGenerator.generateUniqueNickname() }
+        verify(exactly = 1) { userRepositoryPort.save(any()) }
+    }
 
-        test("유저 저장 후 토큰 생성 실패 - createAccessToken 예외 전파 확인") {
-            // Given
-            val idToken = "valid-id-token"
-            val oauthInfoPayload = OauthInfoPayload(
-                providerType = ProviderType.KAKAO,
-                oid = "kakao-oid-new",
-                email = "new@example.com",
-                name = null,
-                imageUrl = null,
-            )
-            val command = RegisterOauthUserCommand(
-                idToken = idToken,
-                providerType = ProviderType.KAKAO,
-                platform = Platform.IOS,
-            )
-            val savedUser =
-                aUser(id = 3L, name = "닉네임", roles = RoleType.USER.role, providerType = ProviderType.KAKAO)
+    @Test
+    @DisplayName("ID token 검증 실패 - oidcTokenValidatorPort 예외 전파 확인")
+    fun `ID token 검증 실패 - oidcTokenValidatorPort 예외 전파 확인`() {
+        // Given
+        val idToken = "invalid-id-token"
+        val command = RegisterOauthUserCommand(
+            idToken = idToken,
+            providerType = ProviderType.KAKAO,
+            platform = Platform.IOS,
+        )
 
-            every {
-                oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
-            } returns oauthInfoPayload
-            every {
-                userRepositoryPort.findByOid(oid = "kakao-oid-new", provider = ProviderType.KAKAO)
-            } returns null
-            every { nicknameGenerator.generateUniqueNickname() } returns "닉네임"
-            every { userRepositoryPort.save(any<User>()) } returns savedUser
-            every {
-                tokenProviderPort.createAccessToken(
-                    id = "3",
-                    roles = listOf(RoleType.USER.role),
-                    name = "닉네임",
-                    providerType = ProviderType.KAKAO,
-                )
-            } throws RuntimeException("토큰 생성 실패")
+        every {
+            oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
+        } throws BusinessException(com.neki.common.api.dto.ResultCode.INVALID_TOKEN_ERROR)
 
-            // When & Then
-            shouldThrow<RuntimeException> {
-                useCase.execute(command)
-            }
-        }
-
-        test("roles 문자열 split - 'USER,ADMIN'을 split(',')하면 2개 원소 리스트 반환") {
-            // Given
-            val idToken = "valid-id-token"
-            val userWithMultipleRoles =
-                aUser(id = 4L, name = "관리자", roles = "USER,ADMIN", providerType = ProviderType.KAKAO)
-            val oauthInfoPayload = OauthInfoPayload(
-                providerType = ProviderType.KAKAO,
-                oid = "kakao-oid-admin",
-                email = "admin@example.com",
-                name = "관리자",
-                imageUrl = null,
-            )
-            val command = RegisterOauthUserCommand(
-                idToken = idToken,
-                providerType = ProviderType.KAKAO,
-                platform = Platform.IOS,
-            )
-
-            every {
-                oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
-            } returns oauthInfoPayload
-            every {
-                userRepositoryPort.findByOid(oid = "kakao-oid-admin", provider = ProviderType.KAKAO)
-            } returns userWithMultipleRoles
-
-            val capturedRoles = mutableListOf<Collection<String>>()
-            every {
-                tokenProviderPort.createAccessToken(
-                    id = "4",
-                    roles = capture(capturedRoles),
-                    name = "관리자",
-                    providerType = ProviderType.KAKAO,
-                )
-            } returns "access-token-admin"
-            every {
-                tokenProviderPort.createRefreshToken(
-                    id = "4",
-                    roles = any(),
-                    name = "관리자",
-                    providerType = ProviderType.KAKAO,
-                )
-            } returns "refresh-token-admin"
-
-            // When
+        // When & Then
+        shouldThrow<BusinessException> {
             useCase.execute(command)
-
-            // Then
-            capturedRoles.size shouldBe 1
-            val roles = capturedRoles[0].toList()
-            roles.size shouldBe 2
-            roles shouldBe listOf("USER", "ADMIN")
         }
-    })
+        verify(exactly = 0) { userRepositoryPort.findByOid(any(), any()) }
+    }
+
+    @Test
+    @DisplayName("유저 저장 후 토큰 생성 실패 - createAccessToken 예외 전파 확인")
+    fun `유저 저장 후 토큰 생성 실패 - createAccessToken 예외 전파 확인`() {
+        // Given
+        val idToken = "valid-id-token"
+        val oauthInfoPayload = OauthInfoPayload(
+            providerType = ProviderType.KAKAO,
+            oid = "kakao-oid-new",
+            email = "new@example.com",
+            name = null,
+            imageUrl = null,
+        )
+        val command = RegisterOauthUserCommand(
+            idToken = idToken,
+            providerType = ProviderType.KAKAO,
+            platform = Platform.IOS,
+        )
+        val savedUser =
+            aUser(id = 3L, name = "닉네임", roles = RoleType.USER.role, providerType = ProviderType.KAKAO)
+
+        every {
+            oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
+        } returns oauthInfoPayload
+        every {
+            userRepositoryPort.findByOid(oid = "kakao-oid-new", provider = ProviderType.KAKAO)
+        } returns null
+        every { nicknameGenerator.generateUniqueNickname() } returns "닉네임"
+        every { userRepositoryPort.save(any<User>()) } returns savedUser
+        every {
+            tokenProviderPort.createAccessToken(
+                id = "3",
+                roles = listOf(RoleType.USER.role),
+                name = "닉네임",
+                providerType = ProviderType.KAKAO,
+            )
+        } throws RuntimeException("토큰 생성 실패")
+
+        // When & Then
+        shouldThrow<RuntimeException> {
+            useCase.execute(command)
+        }
+    }
+
+    @Test
+    @DisplayName("roles 문자열 split - 'USER,ADMIN'을 split(',')하면 2개 원소 리스트 반환")
+    fun `roles 문자열 split - 'USER,ADMIN'을 split(',')하면 2개 원소 리스트 반환`() {
+        // Given
+        val idToken = "valid-id-token"
+        val userWithMultipleRoles =
+            aUser(id = 4L, name = "관리자", roles = "USER,ADMIN", providerType = ProviderType.KAKAO)
+        val oauthInfoPayload = OauthInfoPayload(
+            providerType = ProviderType.KAKAO,
+            oid = "kakao-oid-admin",
+            email = "admin@example.com",
+            name = "관리자",
+            imageUrl = null,
+        )
+        val command = RegisterOauthUserCommand(
+            idToken = idToken,
+            providerType = ProviderType.KAKAO,
+            platform = Platform.IOS,
+        )
+
+        every {
+            oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
+        } returns oauthInfoPayload
+        every {
+            userRepositoryPort.findByOid(oid = "kakao-oid-admin", provider = ProviderType.KAKAO)
+        } returns userWithMultipleRoles
+
+        val capturedRoles = mutableListOf<Collection<String>>()
+        every {
+            tokenProviderPort.createAccessToken(
+                id = "4",
+                roles = capture(capturedRoles),
+                name = "관리자",
+                providerType = ProviderType.KAKAO,
+            )
+        } returns "access-token-admin"
+        every {
+            tokenProviderPort.createRefreshToken(
+                id = "4",
+                roles = any(),
+                name = "관리자",
+                providerType = ProviderType.KAKAO,
+            )
+        } returns "refresh-token-admin"
+
+        // When
+        useCase.execute(command)
+
+        // Then
+        capturedRoles.size shouldBe 1
+        val roles = capturedRoles[0].toList()
+        roles.size shouldBe 2
+        roles shouldBe listOf("USER", "ADMIN")
+    }
+}

--- a/src/test/kotlin/com/neki/user/application/usecase/OauthLoginUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/OauthLoginUseCaseTest.kt
@@ -1,0 +1,270 @@
+package com.neki.user.application.usecase
+
+import com.neki.common.exception.BusinessException
+import com.neki.testfixture.FakeTransactionRunner
+import com.neki.testfixture.aUser
+import com.neki.user.application.command.RegisterOauthUserCommand
+import com.neki.user.application.contract.OauthInfoPayload
+import com.neki.user.application.port.AuthTokenProviderPort
+import com.neki.user.application.port.NicknameGeneratorPort
+import com.neki.user.application.port.OidcTokenValidatorPort
+import com.neki.user.application.port.UserRepositoryPort
+import com.neki.user.domain.entity.User
+import com.neki.user.domain.enums.Platform
+import com.neki.user.domain.enums.ProviderType
+import com.neki.user.domain.enums.RoleType
+import com.neki.user.infra.security.config.OauthProperties
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.web.client.RestClient
+
+class OauthLoginUseCaseTest : FunSpec({
+
+    lateinit var oauthProperties: OauthProperties
+    lateinit var oidcTokenValidatorPort: OidcTokenValidatorPort
+    lateinit var restClient: RestClient
+    lateinit var tokenProviderPort: AuthTokenProviderPort
+    lateinit var userRepositoryPort: UserRepositoryPort
+    lateinit var nicknameGenerator: NicknameGeneratorPort
+    lateinit var transactionRunner: FakeTransactionRunner
+    lateinit var useCase: OauthLoginUseCase
+
+    beforeTest {
+        oauthProperties = OauthProperties()
+        oidcTokenValidatorPort = mockk()
+        restClient = mockk()
+        tokenProviderPort = mockk()
+        userRepositoryPort = mockk()
+        nicknameGenerator = mockk()
+        transactionRunner = FakeTransactionRunner()
+
+        useCase = OauthLoginUseCase(
+            oauthProperties = oauthProperties,
+            oidcTokenValidatorPort = oidcTokenValidatorPort,
+            restClient = restClient,
+            tokenProviderPort = tokenProviderPort,
+            userRepositoryPort = userRepositoryPort,
+            nicknameGenerator = nicknameGenerator,
+            transactionRunner = transactionRunner,
+        )
+    }
+
+    test("기존 유저 로그인 - ID token 검증 후 유저 조회 및 토큰 생성") {
+        // Given
+        val idToken = "valid-id-token"
+        val existingUser = aUser(id = 1L, name = "기존유저", roles = RoleType.USER.role, providerType = ProviderType.KAKAO)
+        val oauthInfoPayload = OauthInfoPayload(
+            providerType = ProviderType.KAKAO,
+            oid = "kakao-oid-123",
+            email = "existing@example.com",
+            name = "기존유저",
+            imageUrl = null,
+        )
+        val command = RegisterOauthUserCommand(
+            idToken = idToken,
+            providerType = ProviderType.KAKAO,
+            platform = Platform.IOS,
+        )
+
+        every {
+            oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
+        } returns oauthInfoPayload
+        every {
+            userRepositoryPort.findByOid(oid = "kakao-oid-123", provider = ProviderType.KAKAO)
+        } returns existingUser
+        every {
+            tokenProviderPort.createAccessToken(
+                id = "1",
+                roles = listOf(RoleType.USER.role),
+                name = "기존유저",
+                providerType = ProviderType.KAKAO,
+            )
+        } returns "access-token"
+        every {
+            tokenProviderPort.createRefreshToken(
+                id = "1",
+                roles = listOf(RoleType.USER.role),
+                name = "기존유저",
+                providerType = ProviderType.KAKAO,
+            )
+        } returns "refresh-token"
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.accessToken shouldBe "access-token"
+        result.refreshToken shouldBe "refresh-token"
+        verify(exactly = 0) { nicknameGenerator.generateUniqueNickname() }
+        verify(exactly = 0) { userRepositoryPort.save(any()) }
+    }
+
+    test("신규 유저 가입 - 미존재 유저 감지 후 닉네임 생성 및 저장 후 토큰 생성") {
+        // Given
+        val idToken = "valid-id-token"
+        val oauthInfoPayload = OauthInfoPayload(
+            providerType = ProviderType.KAKAO,
+            oid = "kakao-oid-new",
+            email = "new@example.com",
+            name = null,
+            imageUrl = null,
+        )
+        val command = RegisterOauthUserCommand(
+            idToken = idToken,
+            providerType = ProviderType.KAKAO,
+            platform = Platform.IOS,
+        )
+        val savedUser = aUser(id = 2L, name = "랜덤닉네임", roles = RoleType.USER.role, providerType = ProviderType.KAKAO)
+
+        every {
+            oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
+        } returns oauthInfoPayload
+        every {
+            userRepositoryPort.findByOid(oid = "kakao-oid-new", provider = ProviderType.KAKAO)
+        } returns null
+        every { nicknameGenerator.generateUniqueNickname() } returns "랜덤닉네임"
+        every { userRepositoryPort.save(any<User>()) } returns savedUser
+        every {
+            tokenProviderPort.createAccessToken(
+                id = "2",
+                roles = listOf(RoleType.USER.role),
+                name = "랜덤닉네임",
+                providerType = ProviderType.KAKAO,
+            )
+        } returns "new-access-token"
+        every {
+            tokenProviderPort.createRefreshToken(
+                id = "2",
+                roles = listOf(RoleType.USER.role),
+                name = "랜덤닉네임",
+                providerType = ProviderType.KAKAO,
+            )
+        } returns "new-refresh-token"
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.accessToken shouldBe "new-access-token"
+        result.refreshToken shouldBe "new-refresh-token"
+        verify(exactly = 1) { nicknameGenerator.generateUniqueNickname() }
+        verify(exactly = 1) { userRepositoryPort.save(any()) }
+    }
+
+    test("ID token 검증 실패 - oidcTokenValidatorPort 예외 전파 확인") {
+        // Given
+        val idToken = "invalid-id-token"
+        val command = RegisterOauthUserCommand(
+            idToken = idToken,
+            providerType = ProviderType.KAKAO,
+            platform = Platform.IOS,
+        )
+
+        every {
+            oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
+        } throws BusinessException(com.neki.common.api.dto.ResultCode.INVALID_TOKEN_ERROR)
+
+        // When & Then
+        shouldThrow<BusinessException> {
+            useCase.execute(command)
+        }
+        verify(exactly = 0) { userRepositoryPort.findByOid(any(), any()) }
+    }
+
+    test("유저 저장 후 토큰 생성 실패 - createAccessToken 예외 전파 확인") {
+        // Given
+        val idToken = "valid-id-token"
+        val oauthInfoPayload = OauthInfoPayload(
+            providerType = ProviderType.KAKAO,
+            oid = "kakao-oid-new",
+            email = "new@example.com",
+            name = null,
+            imageUrl = null,
+        )
+        val command = RegisterOauthUserCommand(
+            idToken = idToken,
+            providerType = ProviderType.KAKAO,
+            platform = Platform.IOS,
+        )
+        val savedUser = aUser(id = 3L, name = "닉네임", roles = RoleType.USER.role, providerType = ProviderType.KAKAO)
+
+        every {
+            oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
+        } returns oauthInfoPayload
+        every {
+            userRepositoryPort.findByOid(oid = "kakao-oid-new", provider = ProviderType.KAKAO)
+        } returns null
+        every { nicknameGenerator.generateUniqueNickname() } returns "닉네임"
+        every { userRepositoryPort.save(any<User>()) } returns savedUser
+        every {
+            tokenProviderPort.createAccessToken(
+                id = "3",
+                roles = listOf(RoleType.USER.role),
+                name = "닉네임",
+                providerType = ProviderType.KAKAO,
+            )
+        } throws RuntimeException("토큰 생성 실패")
+
+        // When & Then
+        shouldThrow<RuntimeException> {
+            useCase.execute(command)
+        }
+    }
+
+    test("roles 문자열 split - 'USER,ADMIN'을 split(',')하면 2개 원소 리스트 반환") {
+        // Given
+        val idToken = "valid-id-token"
+        val userWithMultipleRoles = aUser(id = 4L, name = "관리자", roles = "USER,ADMIN", providerType = ProviderType.KAKAO)
+        val oauthInfoPayload = OauthInfoPayload(
+            providerType = ProviderType.KAKAO,
+            oid = "kakao-oid-admin",
+            email = "admin@example.com",
+            name = "관리자",
+            imageUrl = null,
+        )
+        val command = RegisterOauthUserCommand(
+            idToken = idToken,
+            providerType = ProviderType.KAKAO,
+            platform = Platform.IOS,
+        )
+
+        every {
+            oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
+        } returns oauthInfoPayload
+        every {
+            userRepositoryPort.findByOid(oid = "kakao-oid-admin", provider = ProviderType.KAKAO)
+        } returns userWithMultipleRoles
+
+        val capturedRoles = mutableListOf<Collection<String>>()
+        every {
+            tokenProviderPort.createAccessToken(
+                id = "4",
+                roles = capture(capturedRoles),
+                name = "관리자",
+                providerType = ProviderType.KAKAO,
+            )
+        } returns "access-token-admin"
+        every {
+            tokenProviderPort.createRefreshToken(
+                id = "4",
+                roles = any(),
+                name = "관리자",
+                providerType = ProviderType.KAKAO,
+            )
+        } returns "refresh-token-admin"
+
+        // When
+        useCase.execute(command)
+
+        // Then
+        capturedRoles.size shouldBe 1
+        val roles = capturedRoles[0].toList()
+        roles.size shouldBe 2
+        roles shouldBe listOf("USER", "ADMIN")
+    }
+})

--- a/src/test/kotlin/com/neki/user/application/usecase/OauthLoginUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/OauthLoginUseCaseTest.kt
@@ -17,254 +17,258 @@ import com.neki.user.infra.security.config.OauthProperties
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.springframework.web.client.RestClient
 
-class OauthLoginUseCaseTest : FunSpec({
+class OauthLoginUseCaseTest :
+    FunSpec({
 
-    lateinit var oauthProperties: OauthProperties
-    lateinit var oidcTokenValidatorPort: OidcTokenValidatorPort
-    lateinit var restClient: RestClient
-    lateinit var tokenProviderPort: AuthTokenProviderPort
-    lateinit var userRepositoryPort: UserRepositoryPort
-    lateinit var nicknameGenerator: NicknameGeneratorPort
-    lateinit var transactionRunner: FakeTransactionRunner
-    lateinit var useCase: OauthLoginUseCase
+        lateinit var oauthProperties: OauthProperties
+        lateinit var oidcTokenValidatorPort: OidcTokenValidatorPort
+        lateinit var restClient: RestClient
+        lateinit var tokenProviderPort: AuthTokenProviderPort
+        lateinit var userRepositoryPort: UserRepositoryPort
+        lateinit var nicknameGenerator: NicknameGeneratorPort
+        lateinit var transactionRunner: FakeTransactionRunner
+        lateinit var useCase: OauthLoginUseCase
 
-    beforeTest {
-        oauthProperties = OauthProperties()
-        oidcTokenValidatorPort = mockk()
-        restClient = mockk()
-        tokenProviderPort = mockk()
-        userRepositoryPort = mockk()
-        nicknameGenerator = mockk()
-        transactionRunner = FakeTransactionRunner()
+        beforeTest {
+            oauthProperties = OauthProperties()
+            oidcTokenValidatorPort = mockk()
+            restClient = mockk()
+            tokenProviderPort = mockk()
+            userRepositoryPort = mockk()
+            nicknameGenerator = mockk()
+            transactionRunner = FakeTransactionRunner()
 
-        useCase = OauthLoginUseCase(
-            oauthProperties = oauthProperties,
-            oidcTokenValidatorPort = oidcTokenValidatorPort,
-            restClient = restClient,
-            tokenProviderPort = tokenProviderPort,
-            userRepositoryPort = userRepositoryPort,
-            nicknameGenerator = nicknameGenerator,
-            transactionRunner = transactionRunner,
-        )
-    }
-
-    test("기존 유저 로그인 - ID token 검증 후 유저 조회 및 토큰 생성") {
-        // Given
-        val idToken = "valid-id-token"
-        val existingUser = aUser(id = 1L, name = "기존유저", roles = RoleType.USER.role, providerType = ProviderType.KAKAO)
-        val oauthInfoPayload = OauthInfoPayload(
-            providerType = ProviderType.KAKAO,
-            oid = "kakao-oid-123",
-            email = "existing@example.com",
-            name = "기존유저",
-            imageUrl = null,
-        )
-        val command = RegisterOauthUserCommand(
-            idToken = idToken,
-            providerType = ProviderType.KAKAO,
-            platform = Platform.IOS,
-        )
-
-        every {
-            oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
-        } returns oauthInfoPayload
-        every {
-            userRepositoryPort.findByOid(oid = "kakao-oid-123", provider = ProviderType.KAKAO)
-        } returns existingUser
-        every {
-            tokenProviderPort.createAccessToken(
-                id = "1",
-                roles = listOf(RoleType.USER.role),
-                name = "기존유저",
-                providerType = ProviderType.KAKAO,
+            useCase = OauthLoginUseCase(
+                oauthProperties = oauthProperties,
+                oidcTokenValidatorPort = oidcTokenValidatorPort,
+                restClient = restClient,
+                tokenProviderPort = tokenProviderPort,
+                userRepositoryPort = userRepositoryPort,
+                nicknameGenerator = nicknameGenerator,
+                transactionRunner = transactionRunner,
             )
-        } returns "access-token"
-        every {
-            tokenProviderPort.createRefreshToken(
-                id = "1",
-                roles = listOf(RoleType.USER.role),
-                name = "기존유저",
-                providerType = ProviderType.KAKAO,
-            )
-        } returns "refresh-token"
-
-        // When
-        val result = useCase.execute(command)
-
-        // Then
-        result.accessToken shouldBe "access-token"
-        result.refreshToken shouldBe "refresh-token"
-        verify(exactly = 0) { nicknameGenerator.generateUniqueNickname() }
-        verify(exactly = 0) { userRepositoryPort.save(any()) }
-    }
-
-    test("신규 유저 가입 - 미존재 유저 감지 후 닉네임 생성 및 저장 후 토큰 생성") {
-        // Given
-        val idToken = "valid-id-token"
-        val oauthInfoPayload = OauthInfoPayload(
-            providerType = ProviderType.KAKAO,
-            oid = "kakao-oid-new",
-            email = "new@example.com",
-            name = null,
-            imageUrl = null,
-        )
-        val command = RegisterOauthUserCommand(
-            idToken = idToken,
-            providerType = ProviderType.KAKAO,
-            platform = Platform.IOS,
-        )
-        val savedUser = aUser(id = 2L, name = "랜덤닉네임", roles = RoleType.USER.role, providerType = ProviderType.KAKAO)
-
-        every {
-            oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
-        } returns oauthInfoPayload
-        every {
-            userRepositoryPort.findByOid(oid = "kakao-oid-new", provider = ProviderType.KAKAO)
-        } returns null
-        every { nicknameGenerator.generateUniqueNickname() } returns "랜덤닉네임"
-        every { userRepositoryPort.save(any<User>()) } returns savedUser
-        every {
-            tokenProviderPort.createAccessToken(
-                id = "2",
-                roles = listOf(RoleType.USER.role),
-                name = "랜덤닉네임",
-                providerType = ProviderType.KAKAO,
-            )
-        } returns "new-access-token"
-        every {
-            tokenProviderPort.createRefreshToken(
-                id = "2",
-                roles = listOf(RoleType.USER.role),
-                name = "랜덤닉네임",
-                providerType = ProviderType.KAKAO,
-            )
-        } returns "new-refresh-token"
-
-        // When
-        val result = useCase.execute(command)
-
-        // Then
-        result.accessToken shouldBe "new-access-token"
-        result.refreshToken shouldBe "new-refresh-token"
-        verify(exactly = 1) { nicknameGenerator.generateUniqueNickname() }
-        verify(exactly = 1) { userRepositoryPort.save(any()) }
-    }
-
-    test("ID token 검증 실패 - oidcTokenValidatorPort 예외 전파 확인") {
-        // Given
-        val idToken = "invalid-id-token"
-        val command = RegisterOauthUserCommand(
-            idToken = idToken,
-            providerType = ProviderType.KAKAO,
-            platform = Platform.IOS,
-        )
-
-        every {
-            oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
-        } throws BusinessException(com.neki.common.api.dto.ResultCode.INVALID_TOKEN_ERROR)
-
-        // When & Then
-        shouldThrow<BusinessException> {
-            useCase.execute(command)
         }
-        verify(exactly = 0) { userRepositoryPort.findByOid(any(), any()) }
-    }
 
-    test("유저 저장 후 토큰 생성 실패 - createAccessToken 예외 전파 확인") {
-        // Given
-        val idToken = "valid-id-token"
-        val oauthInfoPayload = OauthInfoPayload(
-            providerType = ProviderType.KAKAO,
-            oid = "kakao-oid-new",
-            email = "new@example.com",
-            name = null,
-            imageUrl = null,
-        )
-        val command = RegisterOauthUserCommand(
-            idToken = idToken,
-            providerType = ProviderType.KAKAO,
-            platform = Platform.IOS,
-        )
-        val savedUser = aUser(id = 3L, name = "닉네임", roles = RoleType.USER.role, providerType = ProviderType.KAKAO)
-
-        every {
-            oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
-        } returns oauthInfoPayload
-        every {
-            userRepositoryPort.findByOid(oid = "kakao-oid-new", provider = ProviderType.KAKAO)
-        } returns null
-        every { nicknameGenerator.generateUniqueNickname() } returns "닉네임"
-        every { userRepositoryPort.save(any<User>()) } returns savedUser
-        every {
-            tokenProviderPort.createAccessToken(
-                id = "3",
-                roles = listOf(RoleType.USER.role),
-                name = "닉네임",
+        test("기존 유저 로그인 - ID token 검증 후 유저 조회 및 토큰 생성") {
+            // Given
+            val idToken = "valid-id-token"
+            val existingUser =
+                aUser(id = 1L, name = "기존유저", roles = RoleType.USER.role, providerType = ProviderType.KAKAO)
+            val oauthInfoPayload = OauthInfoPayload(
                 providerType = ProviderType.KAKAO,
+                oid = "kakao-oid-123",
+                email = "existing@example.com",
+                name = "기존유저",
+                imageUrl = null,
             )
-        } throws RuntimeException("토큰 생성 실패")
+            val command = RegisterOauthUserCommand(
+                idToken = idToken,
+                providerType = ProviderType.KAKAO,
+                platform = Platform.IOS,
+            )
 
-        // When & Then
-        shouldThrow<RuntimeException> {
-            useCase.execute(command)
+            every {
+                oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
+            } returns oauthInfoPayload
+            every {
+                userRepositoryPort.findByOid(oid = "kakao-oid-123", provider = ProviderType.KAKAO)
+            } returns existingUser
+            every {
+                tokenProviderPort.createAccessToken(
+                    id = "1",
+                    roles = listOf(RoleType.USER.role),
+                    name = "기존유저",
+                    providerType = ProviderType.KAKAO,
+                )
+            } returns "access-token"
+            every {
+                tokenProviderPort.createRefreshToken(
+                    id = "1",
+                    roles = listOf(RoleType.USER.role),
+                    name = "기존유저",
+                    providerType = ProviderType.KAKAO,
+                )
+            } returns "refresh-token"
+
+            // When
+            val result = useCase.execute(command)
+
+            // Then
+            result.accessToken shouldBe "access-token"
+            result.refreshToken shouldBe "refresh-token"
+            verify(exactly = 0) { nicknameGenerator.generateUniqueNickname() }
+            verify(exactly = 0) { userRepositoryPort.save(any()) }
         }
-    }
 
-    test("roles 문자열 split - 'USER,ADMIN'을 split(',')하면 2개 원소 리스트 반환") {
-        // Given
-        val idToken = "valid-id-token"
-        val userWithMultipleRoles = aUser(id = 4L, name = "관리자", roles = "USER,ADMIN", providerType = ProviderType.KAKAO)
-        val oauthInfoPayload = OauthInfoPayload(
-            providerType = ProviderType.KAKAO,
-            oid = "kakao-oid-admin",
-            email = "admin@example.com",
-            name = "관리자",
-            imageUrl = null,
-        )
-        val command = RegisterOauthUserCommand(
-            idToken = idToken,
-            providerType = ProviderType.KAKAO,
-            platform = Platform.IOS,
-        )
-
-        every {
-            oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
-        } returns oauthInfoPayload
-        every {
-            userRepositoryPort.findByOid(oid = "kakao-oid-admin", provider = ProviderType.KAKAO)
-        } returns userWithMultipleRoles
-
-        val capturedRoles = mutableListOf<Collection<String>>()
-        every {
-            tokenProviderPort.createAccessToken(
-                id = "4",
-                roles = capture(capturedRoles),
-                name = "관리자",
+        test("신규 유저 가입 - 미존재 유저 감지 후 닉네임 생성 및 저장 후 토큰 생성") {
+            // Given
+            val idToken = "valid-id-token"
+            val oauthInfoPayload = OauthInfoPayload(
                 providerType = ProviderType.KAKAO,
+                oid = "kakao-oid-new",
+                email = "new@example.com",
+                name = null,
+                imageUrl = null,
             )
-        } returns "access-token-admin"
-        every {
-            tokenProviderPort.createRefreshToken(
-                id = "4",
-                roles = any(),
-                name = "관리자",
+            val command = RegisterOauthUserCommand(
+                idToken = idToken,
                 providerType = ProviderType.KAKAO,
+                platform = Platform.IOS,
             )
-        } returns "refresh-token-admin"
+            val savedUser =
+                aUser(id = 2L, name = "랜덤닉네임", roles = RoleType.USER.role, providerType = ProviderType.KAKAO)
 
-        // When
-        useCase.execute(command)
+            every {
+                oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
+            } returns oauthInfoPayload
+            every {
+                userRepositoryPort.findByOid(oid = "kakao-oid-new", provider = ProviderType.KAKAO)
+            } returns null
+            every { nicknameGenerator.generateUniqueNickname() } returns "랜덤닉네임"
+            every { userRepositoryPort.save(any<User>()) } returns savedUser
+            every {
+                tokenProviderPort.createAccessToken(
+                    id = "2",
+                    roles = listOf(RoleType.USER.role),
+                    name = "랜덤닉네임",
+                    providerType = ProviderType.KAKAO,
+                )
+            } returns "new-access-token"
+            every {
+                tokenProviderPort.createRefreshToken(
+                    id = "2",
+                    roles = listOf(RoleType.USER.role),
+                    name = "랜덤닉네임",
+                    providerType = ProviderType.KAKAO,
+                )
+            } returns "new-refresh-token"
 
-        // Then
-        capturedRoles.size shouldBe 1
-        val roles = capturedRoles[0].toList()
-        roles.size shouldBe 2
-        roles shouldBe listOf("USER", "ADMIN")
-    }
-})
+            // When
+            val result = useCase.execute(command)
+
+            // Then
+            result.accessToken shouldBe "new-access-token"
+            result.refreshToken shouldBe "new-refresh-token"
+            verify(exactly = 1) { nicknameGenerator.generateUniqueNickname() }
+            verify(exactly = 1) { userRepositoryPort.save(any()) }
+        }
+
+        test("ID token 검증 실패 - oidcTokenValidatorPort 예외 전파 확인") {
+            // Given
+            val idToken = "invalid-id-token"
+            val command = RegisterOauthUserCommand(
+                idToken = idToken,
+                providerType = ProviderType.KAKAO,
+                platform = Platform.IOS,
+            )
+
+            every {
+                oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
+            } throws BusinessException(com.neki.common.api.dto.ResultCode.INVALID_TOKEN_ERROR)
+
+            // When & Then
+            shouldThrow<BusinessException> {
+                useCase.execute(command)
+            }
+            verify(exactly = 0) { userRepositoryPort.findByOid(any(), any()) }
+        }
+
+        test("유저 저장 후 토큰 생성 실패 - createAccessToken 예외 전파 확인") {
+            // Given
+            val idToken = "valid-id-token"
+            val oauthInfoPayload = OauthInfoPayload(
+                providerType = ProviderType.KAKAO,
+                oid = "kakao-oid-new",
+                email = "new@example.com",
+                name = null,
+                imageUrl = null,
+            )
+            val command = RegisterOauthUserCommand(
+                idToken = idToken,
+                providerType = ProviderType.KAKAO,
+                platform = Platform.IOS,
+            )
+            val savedUser =
+                aUser(id = 3L, name = "닉네임", roles = RoleType.USER.role, providerType = ProviderType.KAKAO)
+
+            every {
+                oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
+            } returns oauthInfoPayload
+            every {
+                userRepositoryPort.findByOid(oid = "kakao-oid-new", provider = ProviderType.KAKAO)
+            } returns null
+            every { nicknameGenerator.generateUniqueNickname() } returns "닉네임"
+            every { userRepositoryPort.save(any<User>()) } returns savedUser
+            every {
+                tokenProviderPort.createAccessToken(
+                    id = "3",
+                    roles = listOf(RoleType.USER.role),
+                    name = "닉네임",
+                    providerType = ProviderType.KAKAO,
+                )
+            } throws RuntimeException("토큰 생성 실패")
+
+            // When & Then
+            shouldThrow<RuntimeException> {
+                useCase.execute(command)
+            }
+        }
+
+        test("roles 문자열 split - 'USER,ADMIN'을 split(',')하면 2개 원소 리스트 반환") {
+            // Given
+            val idToken = "valid-id-token"
+            val userWithMultipleRoles =
+                aUser(id = 4L, name = "관리자", roles = "USER,ADMIN", providerType = ProviderType.KAKAO)
+            val oauthInfoPayload = OauthInfoPayload(
+                providerType = ProviderType.KAKAO,
+                oid = "kakao-oid-admin",
+                email = "admin@example.com",
+                name = "관리자",
+                imageUrl = null,
+            )
+            val command = RegisterOauthUserCommand(
+                idToken = idToken,
+                providerType = ProviderType.KAKAO,
+                platform = Platform.IOS,
+            )
+
+            every {
+                oidcTokenValidatorPort.validateIdToken(idToken, ProviderType.KAKAO, Platform.IOS)
+            } returns oauthInfoPayload
+            every {
+                userRepositoryPort.findByOid(oid = "kakao-oid-admin", provider = ProviderType.KAKAO)
+            } returns userWithMultipleRoles
+
+            val capturedRoles = mutableListOf<Collection<String>>()
+            every {
+                tokenProviderPort.createAccessToken(
+                    id = "4",
+                    roles = capture(capturedRoles),
+                    name = "관리자",
+                    providerType = ProviderType.KAKAO,
+                )
+            } returns "access-token-admin"
+            every {
+                tokenProviderPort.createRefreshToken(
+                    id = "4",
+                    roles = any(),
+                    name = "관리자",
+                    providerType = ProviderType.KAKAO,
+                )
+            } returns "refresh-token-admin"
+
+            // When
+            useCase.execute(command)
+
+            // Then
+            capturedRoles.size shouldBe 1
+            val roles = capturedRoles[0].toList()
+            roles.size shouldBe 2
+            roles shouldBe listOf("USER", "ADMIN")
+        }
+    })

--- a/src/test/kotlin/com/neki/user/application/usecase/RefreshTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/RefreshTokenUseCaseTest.kt
@@ -14,82 +14,83 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.springframework.security.core.Authentication
 
-class RefreshTokenUseCaseTest : FunSpec({
+class RefreshTokenUseCaseTest :
+    FunSpec({
 
-    lateinit var tokenProviderPort: AuthTokenProviderPort
-    lateinit var useCase: RefreshTokenUseCase
+        lateinit var tokenProviderPort: AuthTokenProviderPort
+        lateinit var useCase: RefreshTokenUseCase
 
-    beforeTest {
-        tokenProviderPort = mockk()
-        useCase = RefreshTokenUseCase(tokenProviderPort)
-    }
+        beforeTest {
+            tokenProviderPort = mockk()
+            useCase = RefreshTokenUseCase(tokenProviderPort)
+        }
 
-    test("정상 갱신 - 유효한 refresh token으로 새 토큰 쌍 반환") {
-        // Given
-        val refreshToken = "valid-refresh-token"
-        val userPrincipal = UserPrincipal(
-            id = 1L,
-            name = "테스트유저",
-            providerType = ProviderType.KAKAO,
-            email = "test@example.com",
-            roles = setOf("USER"),
-            password = "NO_PASS",
-        )
-        val authentication: Authentication = mockk()
-
-        every { tokenProviderPort.validateRefreshToken(refreshToken) } returns true
-        every { tokenProviderPort.getAuthenticationFromRefreshToken(refreshToken) } returns authentication
-        every { authentication.principal } returns userPrincipal
-        every {
-            tokenProviderPort.createAccessToken(
-                id = "1",
-                roles = listOf("USER"),
+        test("정상 갱신 - 유효한 refresh token으로 새 토큰 쌍 반환") {
+            // Given
+            val refreshToken = "valid-refresh-token"
+            val userPrincipal = UserPrincipal(
+                id = 1L,
                 name = "테스트유저",
                 providerType = ProviderType.KAKAO,
+                email = "test@example.com",
+                roles = setOf("USER"),
+                password = "NO_PASS",
             )
-        } returns "new-access-token"
-        every {
-            tokenProviderPort.createRefreshToken(
-                id = "1",
-                roles = listOf("USER"),
-                name = "테스트유저",
-                providerType = ProviderType.KAKAO,
-            )
-        } returns "new-refresh-token"
+            val authentication: Authentication = mockk()
 
-        // When
-        val result = useCase.execute(RefreshTokenCommand(refreshToken = refreshToken))
+            every { tokenProviderPort.validateRefreshToken(refreshToken) } returns true
+            every { tokenProviderPort.getAuthenticationFromRefreshToken(refreshToken) } returns authentication
+            every { authentication.principal } returns userPrincipal
+            every {
+                tokenProviderPort.createAccessToken(
+                    id = "1",
+                    roles = listOf("USER"),
+                    name = "테스트유저",
+                    providerType = ProviderType.KAKAO,
+                )
+            } returns "new-access-token"
+            every {
+                tokenProviderPort.createRefreshToken(
+                    id = "1",
+                    roles = listOf("USER"),
+                    name = "테스트유저",
+                    providerType = ProviderType.KAKAO,
+                )
+            } returns "new-refresh-token"
 
-        // Then
-        result.accessToken shouldBe "new-access-token"
-        result.refreshToken shouldBe "new-refresh-token"
-        verify(exactly = 1) { tokenProviderPort.validateRefreshToken(refreshToken) }
-        verify(exactly = 1) { tokenProviderPort.getAuthenticationFromRefreshToken(refreshToken) }
-    }
+            // When
+            val result = useCase.execute(RefreshTokenCommand(refreshToken = refreshToken))
 
-    test("유효하지 않은 토큰 - INVALID_TOKEN_ERROR BusinessException 발생") {
-        // Given
-        val invalidToken = "invalid-refresh-token"
-        every { tokenProviderPort.validateRefreshToken(invalidToken) } returns false
-
-        // When & Then
-        val exception = shouldThrow<BusinessException> {
-            useCase.execute(RefreshTokenCommand(refreshToken = invalidToken))
+            // Then
+            result.accessToken shouldBe "new-access-token"
+            result.refreshToken shouldBe "new-refresh-token"
+            verify(exactly = 1) { tokenProviderPort.validateRefreshToken(refreshToken) }
+            verify(exactly = 1) { tokenProviderPort.getAuthenticationFromRefreshToken(refreshToken) }
         }
-        exception.resultCode shouldBe ResultCode.INVALID_TOKEN_ERROR
-        verify(exactly = 0) { tokenProviderPort.getAuthenticationFromRefreshToken(any()) }
-    }
 
-    test("만료된 refresh token - 유효하지 않은 토큰과 동일하게 INVALID_TOKEN_ERROR BusinessException 발생") {
-        // Given: 만료된 토큰도 validateRefreshToken이 false를 반환함
-        val expiredToken = "expired-refresh-token"
-        every { tokenProviderPort.validateRefreshToken(expiredToken) } returns false
+        test("유효하지 않은 토큰 - INVALID_TOKEN_ERROR BusinessException 발생") {
+            // Given
+            val invalidToken = "invalid-refresh-token"
+            every { tokenProviderPort.validateRefreshToken(invalidToken) } returns false
 
-        // When & Then
-        val exception = shouldThrow<BusinessException> {
-            useCase.execute(RefreshTokenCommand(refreshToken = expiredToken))
+            // When & Then
+            val exception = shouldThrow<BusinessException> {
+                useCase.execute(RefreshTokenCommand(refreshToken = invalidToken))
+            }
+            exception.resultCode shouldBe ResultCode.INVALID_TOKEN_ERROR
+            verify(exactly = 0) { tokenProviderPort.getAuthenticationFromRefreshToken(any()) }
         }
-        exception.resultCode shouldBe ResultCode.INVALID_TOKEN_ERROR
-        verify(exactly = 0) { tokenProviderPort.getAuthenticationFromRefreshToken(any()) }
-    }
-})
+
+        test("만료된 refresh token - 유효하지 않은 토큰과 동일하게 INVALID_TOKEN_ERROR BusinessException 발생") {
+            // Given: 만료된 토큰도 validateRefreshToken이 false를 반환함
+            val expiredToken = "expired-refresh-token"
+            every { tokenProviderPort.validateRefreshToken(expiredToken) } returns false
+
+            // When & Then
+            val exception = shouldThrow<BusinessException> {
+                useCase.execute(RefreshTokenCommand(refreshToken = expiredToken))
+            }
+            exception.resultCode shouldBe ResultCode.INVALID_TOKEN_ERROR
+            verify(exactly = 0) { tokenProviderPort.getAuthenticationFromRefreshToken(any()) }
+        }
+    })

--- a/src/test/kotlin/com/neki/user/application/usecase/RefreshTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/RefreshTokenUseCaseTest.kt
@@ -1,0 +1,95 @@
+package com.neki.user.application.usecase
+
+import com.neki.common.api.dto.ResultCode
+import com.neki.common.exception.BusinessException
+import com.neki.user.application.command.RefreshTokenCommand
+import com.neki.user.application.port.AuthTokenProviderPort
+import com.neki.user.domain.enums.ProviderType
+import com.neki.user.infra.security.token.UserPrincipal
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.security.core.Authentication
+
+class RefreshTokenUseCaseTest : FunSpec({
+
+    lateinit var tokenProviderPort: AuthTokenProviderPort
+    lateinit var useCase: RefreshTokenUseCase
+
+    beforeTest {
+        tokenProviderPort = mockk()
+        useCase = RefreshTokenUseCase(tokenProviderPort)
+    }
+
+    test("정상 갱신 - 유효한 refresh token으로 새 토큰 쌍 반환") {
+        // Given
+        val refreshToken = "valid-refresh-token"
+        val userPrincipal = UserPrincipal(
+            id = 1L,
+            name = "테스트유저",
+            providerType = ProviderType.KAKAO,
+            email = "test@example.com",
+            roles = setOf("USER"),
+            password = "NO_PASS",
+        )
+        val authentication: Authentication = mockk()
+
+        every { tokenProviderPort.validateRefreshToken(refreshToken) } returns true
+        every { tokenProviderPort.getAuthenticationFromRefreshToken(refreshToken) } returns authentication
+        every { authentication.principal } returns userPrincipal
+        every {
+            tokenProviderPort.createAccessToken(
+                id = "1",
+                roles = listOf("USER"),
+                name = "테스트유저",
+                providerType = ProviderType.KAKAO,
+            )
+        } returns "new-access-token"
+        every {
+            tokenProviderPort.createRefreshToken(
+                id = "1",
+                roles = listOf("USER"),
+                name = "테스트유저",
+                providerType = ProviderType.KAKAO,
+            )
+        } returns "new-refresh-token"
+
+        // When
+        val result = useCase.execute(RefreshTokenCommand(refreshToken = refreshToken))
+
+        // Then
+        result.accessToken shouldBe "new-access-token"
+        result.refreshToken shouldBe "new-refresh-token"
+        verify(exactly = 1) { tokenProviderPort.validateRefreshToken(refreshToken) }
+        verify(exactly = 1) { tokenProviderPort.getAuthenticationFromRefreshToken(refreshToken) }
+    }
+
+    test("유효하지 않은 토큰 - INVALID_TOKEN_ERROR BusinessException 발생") {
+        // Given
+        val invalidToken = "invalid-refresh-token"
+        every { tokenProviderPort.validateRefreshToken(invalidToken) } returns false
+
+        // When & Then
+        val exception = shouldThrow<BusinessException> {
+            useCase.execute(RefreshTokenCommand(refreshToken = invalidToken))
+        }
+        exception.resultCode shouldBe ResultCode.INVALID_TOKEN_ERROR
+        verify(exactly = 0) { tokenProviderPort.getAuthenticationFromRefreshToken(any()) }
+    }
+
+    test("만료된 refresh token - 유효하지 않은 토큰과 동일하게 INVALID_TOKEN_ERROR BusinessException 발생") {
+        // Given: 만료된 토큰도 validateRefreshToken이 false를 반환함
+        val expiredToken = "expired-refresh-token"
+        every { tokenProviderPort.validateRefreshToken(expiredToken) } returns false
+
+        // When & Then
+        val exception = shouldThrow<BusinessException> {
+            useCase.execute(RefreshTokenCommand(refreshToken = expiredToken))
+        }
+        exception.resultCode shouldBe ResultCode.INVALID_TOKEN_ERROR
+        verify(exactly = 0) { tokenProviderPort.getAuthenticationFromRefreshToken(any()) }
+    }
+})

--- a/src/test/kotlin/com/neki/user/application/usecase/RefreshTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/RefreshTokenUseCaseTest.kt
@@ -7,90 +7,98 @@ import com.neki.user.application.port.AuthTokenProviderPort
 import com.neki.user.domain.enums.ProviderType
 import com.neki.user.infra.security.token.UserPrincipal
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 import org.springframework.security.core.Authentication
 
-class RefreshTokenUseCaseTest :
-    FunSpec({
+class RefreshTokenUseCaseTest {
 
-        lateinit var tokenProviderPort: AuthTokenProviderPort
-        lateinit var useCase: RefreshTokenUseCase
+    lateinit var tokenProviderPort: AuthTokenProviderPort
+    lateinit var useCase: RefreshTokenUseCase
 
-        beforeTest {
-            tokenProviderPort = mockk()
-            useCase = RefreshTokenUseCase(tokenProviderPort)
-        }
+    @BeforeEach
+    fun setUp() {
+        tokenProviderPort = mockk()
+        useCase = RefreshTokenUseCase(tokenProviderPort)
+    }
 
-        test("정상 갱신 - 유효한 refresh token으로 새 토큰 쌍 반환") {
-            // Given
-            val refreshToken = "valid-refresh-token"
-            val userPrincipal = UserPrincipal(
-                id = 1L,
+    @Test
+    @DisplayName("정상 갱신 - 유효한 refresh token으로 새 토큰 쌍 반환")
+    fun `정상 갱신 - 유효한 refresh token으로 새 토큰 쌍 반환`() {
+        // Given
+        val refreshToken = "valid-refresh-token"
+        val userPrincipal = UserPrincipal(
+            id = 1L,
+            name = "테스트유저",
+            providerType = ProviderType.KAKAO,
+            email = "test@example.com",
+            roles = setOf("USER"),
+            password = "NO_PASS",
+        )
+        val authentication: Authentication = mockk()
+
+        every { tokenProviderPort.validateRefreshToken(refreshToken) } returns true
+        every { tokenProviderPort.getAuthenticationFromRefreshToken(refreshToken) } returns authentication
+        every { authentication.principal } returns userPrincipal
+        every {
+            tokenProviderPort.createAccessToken(
+                id = "1",
+                roles = listOf("USER"),
                 name = "테스트유저",
                 providerType = ProviderType.KAKAO,
-                email = "test@example.com",
-                roles = setOf("USER"),
-                password = "NO_PASS",
             )
-            val authentication: Authentication = mockk()
+        } returns "new-access-token"
+        every {
+            tokenProviderPort.createRefreshToken(
+                id = "1",
+                roles = listOf("USER"),
+                name = "테스트유저",
+                providerType = ProviderType.KAKAO,
+            )
+        } returns "new-refresh-token"
 
-            every { tokenProviderPort.validateRefreshToken(refreshToken) } returns true
-            every { tokenProviderPort.getAuthenticationFromRefreshToken(refreshToken) } returns authentication
-            every { authentication.principal } returns userPrincipal
-            every {
-                tokenProviderPort.createAccessToken(
-                    id = "1",
-                    roles = listOf("USER"),
-                    name = "테스트유저",
-                    providerType = ProviderType.KAKAO,
-                )
-            } returns "new-access-token"
-            every {
-                tokenProviderPort.createRefreshToken(
-                    id = "1",
-                    roles = listOf("USER"),
-                    name = "테스트유저",
-                    providerType = ProviderType.KAKAO,
-                )
-            } returns "new-refresh-token"
+        // When
+        val result = useCase.execute(RefreshTokenCommand(refreshToken = refreshToken))
 
-            // When
-            val result = useCase.execute(RefreshTokenCommand(refreshToken = refreshToken))
+        // Then
+        result.accessToken shouldBe "new-access-token"
+        result.refreshToken shouldBe "new-refresh-token"
+        verify(exactly = 1) { tokenProviderPort.validateRefreshToken(refreshToken) }
+        verify(exactly = 1) { tokenProviderPort.getAuthenticationFromRefreshToken(refreshToken) }
+    }
 
-            // Then
-            result.accessToken shouldBe "new-access-token"
-            result.refreshToken shouldBe "new-refresh-token"
-            verify(exactly = 1) { tokenProviderPort.validateRefreshToken(refreshToken) }
-            verify(exactly = 1) { tokenProviderPort.getAuthenticationFromRefreshToken(refreshToken) }
+    @Test
+    @DisplayName("유효하지 않은 토큰 - INVALID_TOKEN_ERROR BusinessException 발생")
+    fun `유효하지 않은 토큰 - INVALID_TOKEN_ERROR BusinessException 발생`() {
+        // Given
+        val invalidToken = "invalid-refresh-token"
+        every { tokenProviderPort.validateRefreshToken(invalidToken) } returns false
+
+        // When & Then
+        val exception = shouldThrow<BusinessException> {
+            useCase.execute(RefreshTokenCommand(refreshToken = invalidToken))
         }
+        exception.resultCode shouldBe ResultCode.INVALID_TOKEN_ERROR
+        verify(exactly = 0) { tokenProviderPort.getAuthenticationFromRefreshToken(any()) }
+    }
 
-        test("유효하지 않은 토큰 - INVALID_TOKEN_ERROR BusinessException 발생") {
-            // Given
-            val invalidToken = "invalid-refresh-token"
-            every { tokenProviderPort.validateRefreshToken(invalidToken) } returns false
+    @Test
+    @DisplayName("만료된 refresh token - 유효하지 않은 토큰과 동일하게 INVALID_TOKEN_ERROR BusinessException 발생")
+    fun `만료된 refresh token - 유효하지 않은 토큰과 동일하게 INVALID_TOKEN_ERROR BusinessException 발생`() {
+        // Given: 만료된 토큰도 validateRefreshToken이 false를 반환함
+        val expiredToken = "expired-refresh-token"
+        every { tokenProviderPort.validateRefreshToken(expiredToken) } returns false
 
-            // When & Then
-            val exception = shouldThrow<BusinessException> {
-                useCase.execute(RefreshTokenCommand(refreshToken = invalidToken))
-            }
-            exception.resultCode shouldBe ResultCode.INVALID_TOKEN_ERROR
-            verify(exactly = 0) { tokenProviderPort.getAuthenticationFromRefreshToken(any()) }
+        // When & Then
+        val exception = shouldThrow<BusinessException> {
+            useCase.execute(RefreshTokenCommand(refreshToken = expiredToken))
         }
-
-        test("만료된 refresh token - 유효하지 않은 토큰과 동일하게 INVALID_TOKEN_ERROR BusinessException 발생") {
-            // Given: 만료된 토큰도 validateRefreshToken이 false를 반환함
-            val expiredToken = "expired-refresh-token"
-            every { tokenProviderPort.validateRefreshToken(expiredToken) } returns false
-
-            // When & Then
-            val exception = shouldThrow<BusinessException> {
-                useCase.execute(RefreshTokenCommand(refreshToken = expiredToken))
-            }
-            exception.resultCode shouldBe ResultCode.INVALID_TOKEN_ERROR
-            verify(exactly = 0) { tokenProviderPort.getAuthenticationFromRefreshToken(any()) }
-        }
-    })
+        exception.resultCode shouldBe ResultCode.INVALID_TOKEN_ERROR
+        verify(exactly = 0) { tokenProviderPort.getAuthenticationFromRefreshToken(any()) }
+    }
+}

--- a/src/test/kotlin/com/neki/user/application/usecase/UpdateMeUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/UpdateMeUseCaseTest.kt
@@ -6,44 +6,50 @@ import com.neki.testfixture.aUser
 import com.neki.user.application.command.UpdateUserInfoCommand
 import com.neki.user.application.port.UserRepositoryPort
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-class UpdateMeUseCaseTest :
-    FunSpec({
+class UpdateMeUseCaseTest {
 
-        lateinit var userRepository: UserRepositoryPort
-        lateinit var useCase: UpdateMeUseCase
+    lateinit var userRepository: UserRepositoryPort
+    lateinit var useCase: UpdateMeUseCase
 
-        beforeTest {
-            userRepository = mockk()
-            useCase = UpdateMeUseCase(userRepository)
+    @BeforeEach
+    fun setUp() {
+        userRepository = mockk()
+        useCase = UpdateMeUseCase(userRepository)
+    }
+
+    @Test
+    @DisplayName("정상 수정 - 유저 존재 시 이름 업데이트 및 변경 확인")
+    fun `정상 수정 - 유저 존재 시 이름 업데이트 및 변경 확인`() {
+        // Given
+        val user = aUser(id = 1L, name = "기존이름")
+        every { userRepository.findById(1L) } returns user
+
+        // When
+        useCase.execute(UpdateUserInfoCommand(userId = 1L, name = "새이름"))
+
+        // Then
+        user.name shouldBe "새이름"
+        verify(exactly = 1) { userRepository.findById(1L) }
+    }
+
+    @Test
+    @DisplayName("미존재 유저 수정 시 NOT_FOUND_USER BusinessException 발생")
+    fun `미존재 유저 수정 시 NOT_FOUND_USER BusinessException 발생`() {
+        // Given
+        every { userRepository.findById(999L) } returns null
+
+        // When & Then
+        val exception = shouldThrow<BusinessException> {
+            useCase.execute(UpdateUserInfoCommand(userId = 999L, name = "새이름"))
         }
-
-        test("정상 수정 - 유저 존재 시 이름 업데이트 및 변경 확인") {
-            // Given
-            val user = aUser(id = 1L, name = "기존이름")
-            every { userRepository.findById(1L) } returns user
-
-            // When
-            useCase.execute(UpdateUserInfoCommand(userId = 1L, name = "새이름"))
-
-            // Then
-            user.name shouldBe "새이름"
-            verify(exactly = 1) { userRepository.findById(1L) }
-        }
-
-        test("미존재 유저 수정 시 NOT_FOUND_USER BusinessException 발생") {
-            // Given
-            every { userRepository.findById(999L) } returns null
-
-            // When & Then
-            val exception = shouldThrow<BusinessException> {
-                useCase.execute(UpdateUserInfoCommand(userId = 999L, name = "새이름"))
-            }
-            exception.resultCode shouldBe ResultCode.NOT_FOUND_USER
-        }
-    })
+        exception.resultCode shouldBe ResultCode.NOT_FOUND_USER
+    }
+}

--- a/src/test/kotlin/com/neki/user/application/usecase/UpdateMeUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/UpdateMeUseCaseTest.kt
@@ -12,37 +12,38 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 
-class UpdateMeUseCaseTest : FunSpec({
+class UpdateMeUseCaseTest :
+    FunSpec({
 
-    lateinit var userRepository: UserRepositoryPort
-    lateinit var useCase: UpdateMeUseCase
+        lateinit var userRepository: UserRepositoryPort
+        lateinit var useCase: UpdateMeUseCase
 
-    beforeTest {
-        userRepository = mockk()
-        useCase = UpdateMeUseCase(userRepository)
-    }
-
-    test("정상 수정 - 유저 존재 시 이름 업데이트 및 변경 확인") {
-        // Given
-        val user = aUser(id = 1L, name = "기존이름")
-        every { userRepository.findById(1L) } returns user
-
-        // When
-        useCase.execute(UpdateUserInfoCommand(userId = 1L, name = "새이름"))
-
-        // Then
-        user.name shouldBe "새이름"
-        verify(exactly = 1) { userRepository.findById(1L) }
-    }
-
-    test("미존재 유저 수정 시 NOT_FOUND_USER BusinessException 발생") {
-        // Given
-        every { userRepository.findById(999L) } returns null
-
-        // When & Then
-        val exception = shouldThrow<BusinessException> {
-            useCase.execute(UpdateUserInfoCommand(userId = 999L, name = "새이름"))
+        beforeTest {
+            userRepository = mockk()
+            useCase = UpdateMeUseCase(userRepository)
         }
-        exception.resultCode shouldBe ResultCode.NOT_FOUND_USER
-    }
-})
+
+        test("정상 수정 - 유저 존재 시 이름 업데이트 및 변경 확인") {
+            // Given
+            val user = aUser(id = 1L, name = "기존이름")
+            every { userRepository.findById(1L) } returns user
+
+            // When
+            useCase.execute(UpdateUserInfoCommand(userId = 1L, name = "새이름"))
+
+            // Then
+            user.name shouldBe "새이름"
+            verify(exactly = 1) { userRepository.findById(1L) }
+        }
+
+        test("미존재 유저 수정 시 NOT_FOUND_USER BusinessException 발생") {
+            // Given
+            every { userRepository.findById(999L) } returns null
+
+            // When & Then
+            val exception = shouldThrow<BusinessException> {
+                useCase.execute(UpdateUserInfoCommand(userId = 999L, name = "새이름"))
+            }
+            exception.resultCode shouldBe ResultCode.NOT_FOUND_USER
+        }
+    })

--- a/src/test/kotlin/com/neki/user/application/usecase/UpdateMeUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/UpdateMeUseCaseTest.kt
@@ -1,0 +1,48 @@
+package com.neki.user.application.usecase
+
+import com.neki.common.api.dto.ResultCode
+import com.neki.common.exception.BusinessException
+import com.neki.testfixture.aUser
+import com.neki.user.application.command.UpdateUserInfoCommand
+import com.neki.user.application.port.UserRepositoryPort
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class UpdateMeUseCaseTest : FunSpec({
+
+    lateinit var userRepository: UserRepositoryPort
+    lateinit var useCase: UpdateMeUseCase
+
+    beforeTest {
+        userRepository = mockk()
+        useCase = UpdateMeUseCase(userRepository)
+    }
+
+    test("정상 수정 - 유저 존재 시 이름 업데이트 및 변경 확인") {
+        // Given
+        val user = aUser(id = 1L, name = "기존이름")
+        every { userRepository.findById(1L) } returns user
+
+        // When
+        useCase.execute(UpdateUserInfoCommand(userId = 1L, name = "새이름"))
+
+        // Then
+        user.name shouldBe "새이름"
+        verify(exactly = 1) { userRepository.findById(1L) }
+    }
+
+    test("미존재 유저 수정 시 NOT_FOUND_USER BusinessException 발생") {
+        // Given
+        every { userRepository.findById(999L) } returns null
+
+        // When & Then
+        val exception = shouldThrow<BusinessException> {
+            useCase.execute(UpdateUserInfoCommand(userId = 999L, name = "새이름"))
+        }
+        exception.resultCode shouldBe ResultCode.NOT_FOUND_USER
+    }
+})

--- a/src/test/kotlin/com/neki/user/application/usecase/UpdateUserProfileImageUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/UpdateUserProfileImageUseCaseTest.kt
@@ -9,194 +9,214 @@ import com.neki.user.application.contract.MediaAvailability
 import com.neki.user.application.port.MediaClientPort
 import com.neki.user.application.port.UserRepositoryPort
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-class UpdateUserProfileImageUseCaseTest :
-    FunSpec({
+class UpdateUserProfileImageUseCaseTest {
 
-        lateinit var userRepository: UserRepositoryPort
-        lateinit var mediaClient: MediaClientPort
-        lateinit var transactionRunner: FakeTransactionRunner
-        lateinit var useCase: UpdateUserProfileImageUseCase
+    lateinit var userRepository: UserRepositoryPort
+    lateinit var mediaClient: MediaClientPort
+    lateinit var transactionRunner: FakeTransactionRunner
+    lateinit var useCase: UpdateUserProfileImageUseCase
 
-        beforeTest {
-            userRepository = mockk()
-            mediaClient = mockk()
-            transactionRunner = FakeTransactionRunner()
-            useCase = UpdateUserProfileImageUseCase(
-                userRepository = userRepository,
-                mediaClient = mediaClient,
-                transactionRunner = transactionRunner,
-            )
-        }
+    @BeforeEach
+    fun setUp() {
+        userRepository = mockk()
+        mediaClient = mockk()
+        transactionRunner = FakeTransactionRunner()
+        useCase = UpdateUserProfileImageUseCase(
+            userRepository = userRepository,
+            mediaClient = mediaClient,
+            transactionRunner = transactionRunner,
+        )
+    }
 
-        test("새 이미지 설정 - 미디어 확인 후 프로필 업데이트 및 이전 이미지 삭제") {
-            // Given
-            val userId = 1L
-            val oldMediaId = 10L
-            val newMediaId = 20L
-            val user = aUser(id = userId, profileImageId = oldMediaId)
+    @Test
+    @DisplayName("새 이미지 설정 - 미디어 확인 후 프로필 업데이트 및 이전 이미지 삭제")
+    fun `새 이미지 설정 - 미디어 확인 후 프로필 업데이트 및 이전 이미지 삭제`() {
+        // Given
+        val userId = 1L
+        val oldMediaId = 10L
+        val newMediaId = 20L
+        val user = aUser(id = userId, profileImageId = oldMediaId)
 
-            every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns
-                MediaAvailability.AVAILABLE
-            every { userRepository.findById(userId) } returns user
-            every { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) } just runs
+        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns
+            MediaAvailability.AVAILABLE
+        every { userRepository.findById(userId) } returns user
+        every { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) } just runs
 
-            // When
+        // When
+        useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
+
+        // Then
+        user.profileImageId shouldBe newMediaId
+        verify(exactly = 1) { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) }
+    }
+
+    @Test
+    @DisplayName("동일 이미지 설정 시 멱등성 - no-op")
+    fun `동일 이미지 설정 시 멱등성 - no-op`() {
+        // Given
+        val userId = 1L
+        val sameMediaId = 10L
+        val user = aUser(id = userId, profileImageId = sameMediaId)
+
+        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = sameMediaId) } returns
+            MediaAvailability.AVAILABLE
+        every { userRepository.findById(userId) } returns user
+
+        // When
+        useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = sameMediaId))
+
+        // Then
+        user.profileImageId shouldBe sameMediaId
+        verify(exactly = 0) { mediaClient.deleteMedia(any(), any()) }
+    }
+
+    @Test
+    @DisplayName("미디어 사용 불가 시 NOT_FOUND BusinessException 발생")
+    fun `미디어 사용 불가 시 NOT_FOUND BusinessException 발생`() {
+        // Given
+        val userId = 1L
+        val newMediaId = 20L
+
+        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns
+            MediaAvailability.UNAVAILABLE
+
+        // When & Then
+        val exception = shouldThrow<BusinessException> {
             useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
-
-            // Then
-            user.profileImageId shouldBe newMediaId
-            verify(exactly = 1) { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) }
         }
+        exception.resultCode shouldBe ResultCode.NOT_FOUND
+        verify(exactly = 0) { userRepository.findById(any()) }
+    }
 
-        test("동일 이미지 설정 시 멱등성 - no-op") {
-            // Given
-            val userId = 1L
-            val sameMediaId = 10L
-            val user = aUser(id = userId, profileImageId = sameMediaId)
+    @Test
+    @DisplayName("트랜잭션 실패 시 미디어 롤백 호출 확인")
+    fun `트랜잭션 실패 시 미디어 롤백 호출 확인`() {
+        // Given
+        val userId = 1L
+        val newMediaId = 20L
 
-            every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = sameMediaId) } returns
-                MediaAvailability.AVAILABLE
-            every { userRepository.findById(userId) } returns user
+        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns
+            MediaAvailability.AVAILABLE
+        every { userRepository.findById(userId) } throws RuntimeException("DB 오류")
+        every { mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId)) } just runs
 
-            // When
-            useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = sameMediaId))
-
-            // Then
-            user.profileImageId shouldBe sameMediaId
-            verify(exactly = 0) { mediaClient.deleteMedia(any(), any()) }
-        }
-
-        test("미디어 사용 불가 시 NOT_FOUND BusinessException 발생") {
-            // Given
-            val userId = 1L
-            val newMediaId = 20L
-
-            every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns
-                MediaAvailability.UNAVAILABLE
-
-            // When & Then
-            val exception = shouldThrow<BusinessException> {
-                useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
-            }
-            exception.resultCode shouldBe ResultCode.NOT_FOUND
-            verify(exactly = 0) { userRepository.findById(any()) }
-        }
-
-        test("트랜잭션 실패 시 미디어 롤백 호출 확인") {
-            // Given
-            val userId = 1L
-            val newMediaId = 20L
-
-            every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns
-                MediaAvailability.AVAILABLE
-            every { userRepository.findById(userId) } throws RuntimeException("DB 오류")
-            every { mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId)) } just runs
-
-            // When & Then
-            shouldThrow<RuntimeException> {
-                useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
-            }
-            verify(exactly = 1) { mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId)) }
-        }
-
-        test("기본 이미지로 변경 (null) - 프로필 null 설정 및 이전 이미지 삭제") {
-            // Given
-            val userId = 1L
-            val oldMediaId = 10L
-            val user = aUser(id = userId, profileImageId = oldMediaId)
-
-            every { userRepository.findById(userId) } returns user
-            every { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) } just runs
-
-            // When
-            useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = null))
-
-            // Then
-            user.profileImageId shouldBe null
-            verify(exactly = 1) { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) }
-        }
-
-        test("이미 기본 이미지인 경우 멱등성 - no-op") {
-            // Given
-            val userId = 1L
-            val user = aUser(id = userId, profileImageId = null)
-
-            every { userRepository.findById(userId) } returns user
-
-            // When
-            useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = null))
-
-            // Then
-            user.profileImageId shouldBe null
-            verify(exactly = 0) { mediaClient.deleteMedia(any(), any()) }
-        }
-
-        test("롤백 중 예외 발생 - 롤백 예외가 전파됨 (원래 예외가 아닌 롤백 예외)") {
-            // Given
-            val userId = 1L
-            val newMediaId = 20L
-            val originalException = RuntimeException("원래 오류")
-            val rollbackException = RuntimeException("롤백 오류")
-
-            every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns
-                MediaAvailability.AVAILABLE
-            every { userRepository.findById(userId) } throws originalException
-            every {
-                mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId))
-            } throws rollbackException
-
-            // When & Then
-            // catch 블록에서 rollbackMediasUploaded가 예외를 던지면, rollback 예외가 전파됨 (원래 예외는 마스킹됨)
-            val thrownException = shouldThrow<RuntimeException> {
-                useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
-            }
-            thrownException.message shouldBe "롤백 오류"
-            verify(exactly = 1) { mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId)) }
-        }
-
-        test("이전 이미지 삭제 실패 - 트랜잭션 성공 후 deleteMedia 예외 발생 시 프로필은 업데이트됨") {
-            // Given
-            val userId = 1L
-            val oldMediaId = 10L
-            val newMediaId = 20L
-            val user = aUser(id = userId, profileImageId = oldMediaId)
-
-            every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns
-                MediaAvailability.AVAILABLE
-            every { userRepository.findById(userId) } returns user
-            every { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) } throws RuntimeException("삭제 실패")
-
-            // When & Then
-            shouldThrow<RuntimeException> {
-                useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
-            }
-            // 프로필은 트랜잭션 내에서 이미 업데이트됨
-            user.profileImageId shouldBe newMediaId
-        }
-
-        test("이전 프로필 이미지 없음 (oldMediaId=null) - 새 이미지 설정 시 이전 이미지 삭제 skip") {
-            // Given
-            val userId = 1L
-            val newMediaId = 20L
-            val user = aUser(id = userId, profileImageId = null) // 기존 프로필 이미지 없음
-
-            every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns
-                MediaAvailability.AVAILABLE
-            every { userRepository.findById(userId) } returns user
-
-            // When
+        // When & Then
+        shouldThrow<RuntimeException> {
             useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
-
-            // Then
-            user.profileImageId shouldBe newMediaId
-            verify(exactly = 0) { mediaClient.deleteMedia(any(), any()) }
         }
-    })
+        verify(exactly = 1) { mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId)) }
+    }
+
+    @Test
+    @DisplayName("기본 이미지로 변경 (null) - 프로필 null 설정 및 이전 이미지 삭제")
+    fun `기본 이미지로 변경 (null) - 프로필 null 설정 및 이전 이미지 삭제`() {
+        // Given
+        val userId = 1L
+        val oldMediaId = 10L
+        val user = aUser(id = userId, profileImageId = oldMediaId)
+
+        every { userRepository.findById(userId) } returns user
+        every { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) } just runs
+
+        // When
+        useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = null))
+
+        // Then
+        user.profileImageId shouldBe null
+        verify(exactly = 1) { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) }
+    }
+
+    @Test
+    @DisplayName("이미 기본 이미지인 경우 멱등성 - no-op")
+    fun `이미 기본 이미지인 경우 멱등성 - no-op`() {
+        // Given
+        val userId = 1L
+        val user = aUser(id = userId, profileImageId = null)
+
+        every { userRepository.findById(userId) } returns user
+
+        // When
+        useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = null))
+
+        // Then
+        user.profileImageId shouldBe null
+        verify(exactly = 0) { mediaClient.deleteMedia(any(), any()) }
+    }
+
+    @Test
+    @DisplayName("롤백 중 예외 발생 - 롤백 예외가 전파됨 (원래 예외가 아닌 롤백 예외)")
+    fun `롤백 중 예외 발생 - 롤백 예외가 전파됨 (원래 예외가 아닌 롤백 예외)`() {
+        // Given
+        val userId = 1L
+        val newMediaId = 20L
+        val originalException = RuntimeException("원래 오류")
+        val rollbackException = RuntimeException("롤백 오류")
+
+        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns
+            MediaAvailability.AVAILABLE
+        every { userRepository.findById(userId) } throws originalException
+        every {
+            mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId))
+        } throws rollbackException
+
+        // When & Then
+        // catch 블록에서 rollbackMediasUploaded가 예외를 던지면, rollback 예외가 전파됨 (원래 예외는 마스킹됨)
+        val thrownException = shouldThrow<RuntimeException> {
+            useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
+        }
+        thrownException.message shouldBe "롤백 오류"
+        verify(exactly = 1) { mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId)) }
+    }
+
+    @Test
+    @DisplayName("이전 이미지 삭제 실패 - 트랜잭션 성공 후 deleteMedia 예외 발생 시 프로필은 업데이트됨")
+    fun `이전 이미지 삭제 실패 - 트랜잭션 성공 후 deleteMedia 예외 발생 시 프로필은 업데이트됨`() {
+        // Given
+        val userId = 1L
+        val oldMediaId = 10L
+        val newMediaId = 20L
+        val user = aUser(id = userId, profileImageId = oldMediaId)
+
+        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns
+            MediaAvailability.AVAILABLE
+        every { userRepository.findById(userId) } returns user
+        every { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) } throws RuntimeException("삭제 실패")
+
+        // When & Then
+        shouldThrow<RuntimeException> {
+            useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
+        }
+        // 프로필은 트랜잭션 내에서 이미 업데이트됨
+        user.profileImageId shouldBe newMediaId
+    }
+
+    @Test
+    @DisplayName("이전 프로필 이미지 없음 (oldMediaId=null) - 새 이미지 설정 시 이전 이미지 삭제 skip")
+    fun `이전 프로필 이미지 없음 (oldMediaId=null) - 새 이미지 설정 시 이전 이미지 삭제 skip`() {
+        // Given
+        val userId = 1L
+        val newMediaId = 20L
+        val user = aUser(id = userId, profileImageId = null) // 기존 프로필 이미지 없음
+
+        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns
+            MediaAvailability.AVAILABLE
+        every { userRepository.findById(userId) } returns user
+
+        // When
+        useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
+
+        // Then
+        user.profileImageId shouldBe newMediaId
+        verify(exactly = 0) { mediaClient.deleteMedia(any(), any()) }
+    }
+}

--- a/src/test/kotlin/com/neki/user/application/usecase/UpdateUserProfileImageUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/UpdateUserProfileImageUseCaseTest.kt
@@ -17,178 +17,186 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 
-class UpdateUserProfileImageUseCaseTest : FunSpec({
+class UpdateUserProfileImageUseCaseTest :
+    FunSpec({
 
-    lateinit var userRepository: UserRepositoryPort
-    lateinit var mediaClient: MediaClientPort
-    lateinit var transactionRunner: FakeTransactionRunner
-    lateinit var useCase: UpdateUserProfileImageUseCase
+        lateinit var userRepository: UserRepositoryPort
+        lateinit var mediaClient: MediaClientPort
+        lateinit var transactionRunner: FakeTransactionRunner
+        lateinit var useCase: UpdateUserProfileImageUseCase
 
-    beforeTest {
-        userRepository = mockk()
-        mediaClient = mockk()
-        transactionRunner = FakeTransactionRunner()
-        useCase = UpdateUserProfileImageUseCase(
-            userRepository = userRepository,
-            mediaClient = mediaClient,
-            transactionRunner = transactionRunner,
-        )
-    }
-
-    test("새 이미지 설정 - 미디어 확인 후 프로필 업데이트 및 이전 이미지 삭제") {
-        // Given
-        val userId = 1L
-        val oldMediaId = 10L
-        val newMediaId = 20L
-        val user = aUser(id = userId, profileImageId = oldMediaId)
-
-        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns MediaAvailability.AVAILABLE
-        every { userRepository.findById(userId) } returns user
-        every { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) } just runs
-
-        // When
-        useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
-
-        // Then
-        user.profileImageId shouldBe newMediaId
-        verify(exactly = 1) { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) }
-    }
-
-    test("동일 이미지 설정 시 멱등성 - no-op") {
-        // Given
-        val userId = 1L
-        val sameMediaId = 10L
-        val user = aUser(id = userId, profileImageId = sameMediaId)
-
-        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = sameMediaId) } returns MediaAvailability.AVAILABLE
-        every { userRepository.findById(userId) } returns user
-
-        // When
-        useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = sameMediaId))
-
-        // Then
-        user.profileImageId shouldBe sameMediaId
-        verify(exactly = 0) { mediaClient.deleteMedia(any(), any()) }
-    }
-
-    test("미디어 사용 불가 시 NOT_FOUND BusinessException 발생") {
-        // Given
-        val userId = 1L
-        val newMediaId = 20L
-
-        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns MediaAvailability.UNAVAILABLE
-
-        // When & Then
-        val exception = shouldThrow<BusinessException> {
-            useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
+        beforeTest {
+            userRepository = mockk()
+            mediaClient = mockk()
+            transactionRunner = FakeTransactionRunner()
+            useCase = UpdateUserProfileImageUseCase(
+                userRepository = userRepository,
+                mediaClient = mediaClient,
+                transactionRunner = transactionRunner,
+            )
         }
-        exception.resultCode shouldBe ResultCode.NOT_FOUND
-        verify(exactly = 0) { userRepository.findById(any()) }
-    }
 
-    test("트랜잭션 실패 시 미디어 롤백 호출 확인") {
-        // Given
-        val userId = 1L
-        val newMediaId = 20L
+        test("새 이미지 설정 - 미디어 확인 후 프로필 업데이트 및 이전 이미지 삭제") {
+            // Given
+            val userId = 1L
+            val oldMediaId = 10L
+            val newMediaId = 20L
+            val user = aUser(id = userId, profileImageId = oldMediaId)
 
-        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns MediaAvailability.AVAILABLE
-        every { userRepository.findById(userId) } throws RuntimeException("DB 오류")
-        every { mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId)) } just runs
+            every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns
+                MediaAvailability.AVAILABLE
+            every { userRepository.findById(userId) } returns user
+            every { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) } just runs
 
-        // When & Then
-        shouldThrow<RuntimeException> {
+            // When
             useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
+
+            // Then
+            user.profileImageId shouldBe newMediaId
+            verify(exactly = 1) { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) }
         }
-        verify(exactly = 1) { mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId)) }
-    }
 
-    test("기본 이미지로 변경 (null) - 프로필 null 설정 및 이전 이미지 삭제") {
-        // Given
-        val userId = 1L
-        val oldMediaId = 10L
-        val user = aUser(id = userId, profileImageId = oldMediaId)
+        test("동일 이미지 설정 시 멱등성 - no-op") {
+            // Given
+            val userId = 1L
+            val sameMediaId = 10L
+            val user = aUser(id = userId, profileImageId = sameMediaId)
 
-        every { userRepository.findById(userId) } returns user
-        every { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) } just runs
+            every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = sameMediaId) } returns
+                MediaAvailability.AVAILABLE
+            every { userRepository.findById(userId) } returns user
 
-        // When
-        useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = null))
+            // When
+            useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = sameMediaId))
 
-        // Then
-        user.profileImageId shouldBe null
-        verify(exactly = 1) { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) }
-    }
+            // Then
+            user.profileImageId shouldBe sameMediaId
+            verify(exactly = 0) { mediaClient.deleteMedia(any(), any()) }
+        }
 
-    test("이미 기본 이미지인 경우 멱등성 - no-op") {
-        // Given
-        val userId = 1L
-        val user = aUser(id = userId, profileImageId = null)
+        test("미디어 사용 불가 시 NOT_FOUND BusinessException 발생") {
+            // Given
+            val userId = 1L
+            val newMediaId = 20L
 
-        every { userRepository.findById(userId) } returns user
+            every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns
+                MediaAvailability.UNAVAILABLE
 
-        // When
-        useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = null))
+            // When & Then
+            val exception = shouldThrow<BusinessException> {
+                useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
+            }
+            exception.resultCode shouldBe ResultCode.NOT_FOUND
+            verify(exactly = 0) { userRepository.findById(any()) }
+        }
 
-        // Then
-        user.profileImageId shouldBe null
-        verify(exactly = 0) { mediaClient.deleteMedia(any(), any()) }
-    }
+        test("트랜잭션 실패 시 미디어 롤백 호출 확인") {
+            // Given
+            val userId = 1L
+            val newMediaId = 20L
 
-    test("롤백 중 예외 발생 - 롤백 예외가 전파됨 (원래 예외가 아닌 롤백 예외)") {
-        // Given
-        val userId = 1L
-        val newMediaId = 20L
-        val originalException = RuntimeException("원래 오류")
-        val rollbackException = RuntimeException("롤백 오류")
+            every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns
+                MediaAvailability.AVAILABLE
+            every { userRepository.findById(userId) } throws RuntimeException("DB 오류")
+            every { mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId)) } just runs
 
-        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns MediaAvailability.AVAILABLE
-        every { userRepository.findById(userId) } throws originalException
-        every {
-            mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId))
-        } throws rollbackException
+            // When & Then
+            shouldThrow<RuntimeException> {
+                useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
+            }
+            verify(exactly = 1) { mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId)) }
+        }
 
-        // When & Then
-        // catch 블록에서 rollbackMediasUploaded가 예외를 던지면, rollback 예외가 전파됨 (원래 예외는 마스킹됨)
-        val thrownException = shouldThrow<RuntimeException> {
+        test("기본 이미지로 변경 (null) - 프로필 null 설정 및 이전 이미지 삭제") {
+            // Given
+            val userId = 1L
+            val oldMediaId = 10L
+            val user = aUser(id = userId, profileImageId = oldMediaId)
+
+            every { userRepository.findById(userId) } returns user
+            every { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) } just runs
+
+            // When
+            useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = null))
+
+            // Then
+            user.profileImageId shouldBe null
+            verify(exactly = 1) { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) }
+        }
+
+        test("이미 기본 이미지인 경우 멱등성 - no-op") {
+            // Given
+            val userId = 1L
+            val user = aUser(id = userId, profileImageId = null)
+
+            every { userRepository.findById(userId) } returns user
+
+            // When
+            useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = null))
+
+            // Then
+            user.profileImageId shouldBe null
+            verify(exactly = 0) { mediaClient.deleteMedia(any(), any()) }
+        }
+
+        test("롤백 중 예외 발생 - 롤백 예외가 전파됨 (원래 예외가 아닌 롤백 예외)") {
+            // Given
+            val userId = 1L
+            val newMediaId = 20L
+            val originalException = RuntimeException("원래 오류")
+            val rollbackException = RuntimeException("롤백 오류")
+
+            every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns
+                MediaAvailability.AVAILABLE
+            every { userRepository.findById(userId) } throws originalException
+            every {
+                mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId))
+            } throws rollbackException
+
+            // When & Then
+            // catch 블록에서 rollbackMediasUploaded가 예외를 던지면, rollback 예외가 전파됨 (원래 예외는 마스킹됨)
+            val thrownException = shouldThrow<RuntimeException> {
+                useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
+            }
+            thrownException.message shouldBe "롤백 오류"
+            verify(exactly = 1) { mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId)) }
+        }
+
+        test("이전 이미지 삭제 실패 - 트랜잭션 성공 후 deleteMedia 예외 발생 시 프로필은 업데이트됨") {
+            // Given
+            val userId = 1L
+            val oldMediaId = 10L
+            val newMediaId = 20L
+            val user = aUser(id = userId, profileImageId = oldMediaId)
+
+            every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns
+                MediaAvailability.AVAILABLE
+            every { userRepository.findById(userId) } returns user
+            every { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) } throws RuntimeException("삭제 실패")
+
+            // When & Then
+            shouldThrow<RuntimeException> {
+                useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
+            }
+            // 프로필은 트랜잭션 내에서 이미 업데이트됨
+            user.profileImageId shouldBe newMediaId
+        }
+
+        test("이전 프로필 이미지 없음 (oldMediaId=null) - 새 이미지 설정 시 이전 이미지 삭제 skip") {
+            // Given
+            val userId = 1L
+            val newMediaId = 20L
+            val user = aUser(id = userId, profileImageId = null) // 기존 프로필 이미지 없음
+
+            every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns
+                MediaAvailability.AVAILABLE
+            every { userRepository.findById(userId) } returns user
+
+            // When
             useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
+
+            // Then
+            user.profileImageId shouldBe newMediaId
+            verify(exactly = 0) { mediaClient.deleteMedia(any(), any()) }
         }
-        thrownException.message shouldBe "롤백 오류"
-        verify(exactly = 1) { mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId)) }
-    }
-
-    test("이전 이미지 삭제 실패 - 트랜잭션 성공 후 deleteMedia 예외 발생 시 프로필은 업데이트됨") {
-        // Given
-        val userId = 1L
-        val oldMediaId = 10L
-        val newMediaId = 20L
-        val user = aUser(id = userId, profileImageId = oldMediaId)
-
-        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns MediaAvailability.AVAILABLE
-        every { userRepository.findById(userId) } returns user
-        every { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) } throws RuntimeException("삭제 실패")
-
-        // When & Then
-        shouldThrow<RuntimeException> {
-            useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
-        }
-        // 프로필은 트랜잭션 내에서 이미 업데이트됨
-        user.profileImageId shouldBe newMediaId
-    }
-
-    test("이전 프로필 이미지 없음 (oldMediaId=null) - 새 이미지 설정 시 이전 이미지 삭제 skip") {
-        // Given
-        val userId = 1L
-        val newMediaId = 20L
-        val user = aUser(id = userId, profileImageId = null) // 기존 프로필 이미지 없음
-
-        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns MediaAvailability.AVAILABLE
-        every { userRepository.findById(userId) } returns user
-
-        // When
-        useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
-
-        // Then
-        user.profileImageId shouldBe newMediaId
-        verify(exactly = 0) { mediaClient.deleteMedia(any(), any()) }
-    }
-})
+    })

--- a/src/test/kotlin/com/neki/user/application/usecase/UpdateUserProfileImageUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/UpdateUserProfileImageUseCaseTest.kt
@@ -134,23 +134,25 @@ class UpdateUserProfileImageUseCaseTest : FunSpec({
         verify(exactly = 0) { mediaClient.deleteMedia(any(), any()) }
     }
 
-    test("롤백 중 예외 발생 - 원래 예외가 마스킹되지 않고 전파됨") {
+    test("롤백 중 예외 발생 - 롤백 예외가 전파됨 (원래 예외가 아닌 롤백 예외)") {
         // Given
         val userId = 1L
         val newMediaId = 20L
         val originalException = RuntimeException("원래 오류")
+        val rollbackException = RuntimeException("롤백 오류")
 
         every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns MediaAvailability.AVAILABLE
         every { userRepository.findById(userId) } throws originalException
         every {
             mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId))
-        } throws RuntimeException("롤백 오류")
+        } throws rollbackException
 
         // When & Then
-        // rollback도 예외가 발생할 경우 rollback 예외가 전파됨 (try-catch 내에서 rollback 호출 시)
-        shouldThrow<RuntimeException> {
+        // catch 블록에서 rollbackMediasUploaded가 예외를 던지면, rollback 예외가 전파됨 (원래 예외는 마스킹됨)
+        val thrownException = shouldThrow<RuntimeException> {
             useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
         }
+        thrownException.message shouldBe "롤백 오류"
         verify(exactly = 1) { mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId)) }
     }
 

--- a/src/test/kotlin/com/neki/user/application/usecase/UpdateUserProfileImageUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/user/application/usecase/UpdateUserProfileImageUseCaseTest.kt
@@ -1,0 +1,192 @@
+package com.neki.user.application.usecase
+
+import com.neki.common.api.dto.ResultCode
+import com.neki.common.exception.BusinessException
+import com.neki.testfixture.FakeTransactionRunner
+import com.neki.testfixture.aUser
+import com.neki.user.application.command.UpdateUserProfileImageCommand
+import com.neki.user.application.contract.MediaAvailability
+import com.neki.user.application.port.MediaClientPort
+import com.neki.user.application.port.UserRepositoryPort
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+
+class UpdateUserProfileImageUseCaseTest : FunSpec({
+
+    lateinit var userRepository: UserRepositoryPort
+    lateinit var mediaClient: MediaClientPort
+    lateinit var transactionRunner: FakeTransactionRunner
+    lateinit var useCase: UpdateUserProfileImageUseCase
+
+    beforeTest {
+        userRepository = mockk()
+        mediaClient = mockk()
+        transactionRunner = FakeTransactionRunner()
+        useCase = UpdateUserProfileImageUseCase(
+            userRepository = userRepository,
+            mediaClient = mediaClient,
+            transactionRunner = transactionRunner,
+        )
+    }
+
+    test("새 이미지 설정 - 미디어 확인 후 프로필 업데이트 및 이전 이미지 삭제") {
+        // Given
+        val userId = 1L
+        val oldMediaId = 10L
+        val newMediaId = 20L
+        val user = aUser(id = userId, profileImageId = oldMediaId)
+
+        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns MediaAvailability.AVAILABLE
+        every { userRepository.findById(userId) } returns user
+        every { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) } just runs
+
+        // When
+        useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
+
+        // Then
+        user.profileImageId shouldBe newMediaId
+        verify(exactly = 1) { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) }
+    }
+
+    test("동일 이미지 설정 시 멱등성 - no-op") {
+        // Given
+        val userId = 1L
+        val sameMediaId = 10L
+        val user = aUser(id = userId, profileImageId = sameMediaId)
+
+        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = sameMediaId) } returns MediaAvailability.AVAILABLE
+        every { userRepository.findById(userId) } returns user
+
+        // When
+        useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = sameMediaId))
+
+        // Then
+        user.profileImageId shouldBe sameMediaId
+        verify(exactly = 0) { mediaClient.deleteMedia(any(), any()) }
+    }
+
+    test("미디어 사용 불가 시 NOT_FOUND BusinessException 발생") {
+        // Given
+        val userId = 1L
+        val newMediaId = 20L
+
+        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns MediaAvailability.UNAVAILABLE
+
+        // When & Then
+        val exception = shouldThrow<BusinessException> {
+            useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
+        }
+        exception.resultCode shouldBe ResultCode.NOT_FOUND
+        verify(exactly = 0) { userRepository.findById(any()) }
+    }
+
+    test("트랜잭션 실패 시 미디어 롤백 호출 확인") {
+        // Given
+        val userId = 1L
+        val newMediaId = 20L
+
+        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns MediaAvailability.AVAILABLE
+        every { userRepository.findById(userId) } throws RuntimeException("DB 오류")
+        every { mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId)) } just runs
+
+        // When & Then
+        shouldThrow<RuntimeException> {
+            useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
+        }
+        verify(exactly = 1) { mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId)) }
+    }
+
+    test("기본 이미지로 변경 (null) - 프로필 null 설정 및 이전 이미지 삭제") {
+        // Given
+        val userId = 1L
+        val oldMediaId = 10L
+        val user = aUser(id = userId, profileImageId = oldMediaId)
+
+        every { userRepository.findById(userId) } returns user
+        every { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) } just runs
+
+        // When
+        useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = null))
+
+        // Then
+        user.profileImageId shouldBe null
+        verify(exactly = 1) { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) }
+    }
+
+    test("이미 기본 이미지인 경우 멱등성 - no-op") {
+        // Given
+        val userId = 1L
+        val user = aUser(id = userId, profileImageId = null)
+
+        every { userRepository.findById(userId) } returns user
+
+        // When
+        useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = null))
+
+        // Then
+        user.profileImageId shouldBe null
+        verify(exactly = 0) { mediaClient.deleteMedia(any(), any()) }
+    }
+
+    test("롤백 중 예외 발생 - 원래 예외가 마스킹되지 않고 전파됨") {
+        // Given
+        val userId = 1L
+        val newMediaId = 20L
+        val originalException = RuntimeException("원래 오류")
+
+        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns MediaAvailability.AVAILABLE
+        every { userRepository.findById(userId) } throws originalException
+        every {
+            mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId))
+        } throws RuntimeException("롤백 오류")
+
+        // When & Then
+        // rollback도 예외가 발생할 경우 rollback 예외가 전파됨 (try-catch 내에서 rollback 호출 시)
+        shouldThrow<RuntimeException> {
+            useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
+        }
+        verify(exactly = 1) { mediaClient.rollbackMediasUploaded(ownerId = userId, mediaIds = listOf(newMediaId)) }
+    }
+
+    test("이전 이미지 삭제 실패 - 트랜잭션 성공 후 deleteMedia 예외 발생 시 프로필은 업데이트됨") {
+        // Given
+        val userId = 1L
+        val oldMediaId = 10L
+        val newMediaId = 20L
+        val user = aUser(id = userId, profileImageId = oldMediaId)
+
+        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns MediaAvailability.AVAILABLE
+        every { userRepository.findById(userId) } returns user
+        every { mediaClient.deleteMedia(ownerId = userId, mediaIds = oldMediaId) } throws RuntimeException("삭제 실패")
+
+        // When & Then
+        shouldThrow<RuntimeException> {
+            useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
+        }
+        // 프로필은 트랜잭션 내에서 이미 업데이트됨
+        user.profileImageId shouldBe newMediaId
+    }
+
+    test("이전 프로필 이미지 없음 (oldMediaId=null) - 새 이미지 설정 시 이전 이미지 삭제 skip") {
+        // Given
+        val userId = 1L
+        val newMediaId = 20L
+        val user = aUser(id = userId, profileImageId = null) // 기존 프로필 이미지 없음
+
+        every { mediaClient.verifyMediaUploaded(ownerId = userId, mediaId = newMediaId) } returns MediaAvailability.AVAILABLE
+        every { userRepository.findById(userId) } returns user
+
+        // When
+        useCase.execute(UpdateUserProfileImageCommand(userId = userId, mediaId = newMediaId))
+
+        // Then
+        user.profileImageId shouldBe newMediaId
+        verify(exactly = 0) { mediaClient.deleteMedia(any(), any()) }
+    }
+})


### PR DESCRIPTION
## Summary
- DeleteMeUseCase: 2개 테스트
- UpdateMeUseCase: 2개 테스트
- RefreshTokenUseCase: 3개 테스트 (만료 토큰 포함)
- OauthLoginUseCase: 5개 테스트 (기존/신규 유저, ID token 실패, roles split)
- UpdateUserProfileImageUseCase: 9개 테스트 (멱등성, 롤백, 이전 미디어 삭제 실패 포함)
- GetUserInfoUseCase: 5개 테스트 (mediaClient/termClient 예외 포함)

총 26개 테스트

closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)