### PR TITLE
test: [Pose] UseCase 단위 테스트 추가

### DIFF
--- a/src/test/kotlin/com/neki/pose/application/usecase/GetPoseUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/GetPoseUseCaseTest.kt
@@ -1,0 +1,130 @@
+package com.neki.pose.application.usecase
+
+import com.neki.common.api.dto.ResultCode
+import com.neki.common.exception.BusinessException
+import com.neki.pose.application.command.GetPoseCommand
+import com.neki.pose.application.contract.MediaStorageInfo
+import com.neki.pose.application.contract.PoseWithScrap
+import com.neki.pose.application.port.MediaClientPort
+import com.neki.pose.application.port.PoseRepositoryPort
+import com.neki.pose.application.port.PoseViewCachePort
+import com.neki.testfixture.FakeTransactionRunner
+import com.neki.testfixture.aPose
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDateTime
+
+class GetPoseUseCaseTest : FunSpec({
+
+    lateinit var poseRepository: PoseRepositoryPort
+    lateinit var mediaClient: MediaClientPort
+    lateinit var poseViewCache: PoseViewCachePort
+    lateinit var transactionRunner: FakeTransactionRunner
+    lateinit var useCase: GetPoseUseCase
+
+    beforeTest {
+        poseRepository = mockk()
+        mediaClient = mockk()
+        poseViewCache = mockk()
+        transactionRunner = FakeTransactionRunner()
+        useCase = GetPoseUseCase(poseRepository, mediaClient, poseViewCache, transactionRunner)
+    }
+
+    fun makePoseWithScrap(id: Long = 1L, mediaId: Long = 101L, scraped: Boolean = false): PoseWithScrap {
+        val pose = aPose(id = id, mediaId = mediaId)
+        pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+        return PoseWithScrap(pose = pose, isScraped = scraped)
+    }
+
+    fun makeMediaStorageInfo(mediaId: Long = 101L): MediaStorageInfo = MediaStorageInfo(
+        mediaId = mediaId,
+        storageKey = "pose/image-$mediaId.jpg",
+        contentType = "image/jpeg",
+        width = 800,
+        height = 600,
+    )
+
+    test("신규 조회자 (cache miss) - addViewer=true → 조회수 증가 + 미디어 매핑") {
+        // Given
+        val command = GetPoseCommand(userId = 1L, poseId = 10L)
+        val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
+        every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
+        every { poseViewCache.addViewer(10L, 1L) } returns true // cache miss → 신규 조회자
+        every { poseRepository.incrementViewCount(10L) } returns Unit
+        every { mediaClient.getMediaStorageInfo(101L) } returns makeMediaStorageInfo(101L)
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        verify(exactly = 1) { poseRepository.incrementViewCount(10L) }
+        result.poseId shouldBe 10L
+        result.storageKey shouldBe "pose/image-101.jpg"
+        result.scrap shouldBe false
+    }
+
+    test("재방문자 (cache hit) - addViewer=false → 조회수 미증가") {
+        // Given
+        val command = GetPoseCommand(userId = 1L, poseId = 10L)
+        val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
+        every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
+        every { poseViewCache.addViewer(10L, 1L) } returns false // cache hit → 재방문자
+        every { mediaClient.getMediaStorageInfo(101L) } returns makeMediaStorageInfo(101L)
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        verify(exactly = 0) { poseRepository.incrementViewCount(any()) }
+        result.poseId shouldBe 10L
+    }
+
+    test("포즈 미존재 → BusinessException(NOT_FOUND)") {
+        // Given
+        val command = GetPoseCommand(userId = 1L, poseId = 999L)
+        every { poseRepository.getOwnedPoseWithScrap(1L, 999L) } returns null
+
+        // When / Then
+        val ex = shouldThrow<BusinessException> {
+            useCase.execute(command)
+        }
+        ex.resultCode shouldBe ResultCode.NOT_FOUND
+        verify(exactly = 0) { poseViewCache.addViewer(any(), any()) }
+        verify(exactly = 0) { mediaClient.getMediaStorageInfo(any()) }
+    }
+
+    test("addViewer 캐시 장애 → 예외 전파") {
+        // Given
+        val command = GetPoseCommand(userId = 1L, poseId = 10L)
+        val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
+        every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
+        every { poseViewCache.addViewer(10L, 1L) } throws RuntimeException("Redis 장애")
+
+        // When / Then
+        shouldThrow<RuntimeException> {
+            useCase.execute(command)
+        }
+        verify(exactly = 0) { poseRepository.incrementViewCount(any()) }
+    }
+
+    test("조회수 증가 후 mediaClient 예외 - side effect 발생, 결과 실패") {
+        // Given
+        val command = GetPoseCommand(userId = 1L, poseId = 10L)
+        val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
+        every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
+        every { poseViewCache.addViewer(10L, 1L) } returns true
+        every { poseRepository.incrementViewCount(10L) } returns Unit
+        every { mediaClient.getMediaStorageInfo(101L) } throws RuntimeException("미디어 조회 실패")
+
+        // When / Then
+        shouldThrow<RuntimeException> {
+            useCase.execute(command)
+        }
+        // 조회수는 이미 증가됨 (side effect 발생)
+        verify(exactly = 1) { poseRepository.incrementViewCount(10L) }
+    }
+})

--- a/src/test/kotlin/com/neki/pose/application/usecase/GetPoseUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/GetPoseUseCaseTest.kt
@@ -18,113 +18,114 @@ import io.mockk.mockk
 import io.mockk.verify
 import java.time.LocalDateTime
 
-class GetPoseUseCaseTest : FunSpec({
+class GetPoseUseCaseTest :
+    FunSpec({
 
-    lateinit var poseRepository: PoseRepositoryPort
-    lateinit var mediaClient: MediaClientPort
-    lateinit var poseViewCache: PoseViewCachePort
-    lateinit var transactionRunner: FakeTransactionRunner
-    lateinit var useCase: GetPoseUseCase
+        lateinit var poseRepository: PoseRepositoryPort
+        lateinit var mediaClient: MediaClientPort
+        lateinit var poseViewCache: PoseViewCachePort
+        lateinit var transactionRunner: FakeTransactionRunner
+        lateinit var useCase: GetPoseUseCase
 
-    beforeTest {
-        poseRepository = mockk()
-        mediaClient = mockk()
-        poseViewCache = mockk()
-        transactionRunner = FakeTransactionRunner()
-        useCase = GetPoseUseCase(poseRepository, mediaClient, poseViewCache, transactionRunner)
-    }
-
-    fun makePoseWithScrap(id: Long = 1L, mediaId: Long = 101L, scraped: Boolean = false): PoseWithScrap {
-        val pose = aPose(id = id, mediaId = mediaId)
-        pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
-        return PoseWithScrap(pose = pose, isScraped = scraped)
-    }
-
-    fun makeMediaStorageInfo(mediaId: Long = 101L): MediaStorageInfo = MediaStorageInfo(
-        mediaId = mediaId,
-        storageKey = "pose/image-$mediaId.jpg",
-        contentType = "image/jpeg",
-        width = 800,
-        height = 600,
-    )
-
-    test("신규 조회자 (cache miss) - addViewer=true → 조회수 증가 + 미디어 매핑") {
-        // Given
-        val command = GetPoseCommand(userId = 1L, poseId = 10L)
-        val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
-        every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
-        every { poseViewCache.addViewer(10L, 1L) } returns true // cache miss → 신규 조회자
-        every { poseRepository.incrementViewCount(10L) } returns Unit
-        every { mediaClient.getMediaStorageInfo(101L) } returns makeMediaStorageInfo(101L)
-
-        // When
-        val result = useCase.execute(command)
-
-        // Then
-        verify(exactly = 1) { poseRepository.incrementViewCount(10L) }
-        result.poseId shouldBe 10L
-        result.storageKey shouldBe "pose/image-101.jpg"
-        result.scrap shouldBe false
-    }
-
-    test("재방문자 (cache hit) - addViewer=false → 조회수 미증가") {
-        // Given
-        val command = GetPoseCommand(userId = 1L, poseId = 10L)
-        val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
-        every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
-        every { poseViewCache.addViewer(10L, 1L) } returns false // cache hit → 재방문자
-        every { mediaClient.getMediaStorageInfo(101L) } returns makeMediaStorageInfo(101L)
-
-        // When
-        val result = useCase.execute(command)
-
-        // Then
-        verify(exactly = 0) { poseRepository.incrementViewCount(any()) }
-        result.poseId shouldBe 10L
-    }
-
-    test("포즈 미존재 → BusinessException(NOT_FOUND)") {
-        // Given
-        val command = GetPoseCommand(userId = 1L, poseId = 999L)
-        every { poseRepository.getOwnedPoseWithScrap(1L, 999L) } returns null
-
-        // When / Then
-        val ex = shouldThrow<BusinessException> {
-            useCase.execute(command)
+        beforeTest {
+            poseRepository = mockk()
+            mediaClient = mockk()
+            poseViewCache = mockk()
+            transactionRunner = FakeTransactionRunner()
+            useCase = GetPoseUseCase(poseRepository, mediaClient, poseViewCache, transactionRunner)
         }
-        ex.resultCode shouldBe ResultCode.NOT_FOUND
-        verify(exactly = 0) { poseViewCache.addViewer(any(), any()) }
-        verify(exactly = 0) { mediaClient.getMediaStorageInfo(any()) }
-    }
 
-    test("addViewer 캐시 장애 → 예외 전파") {
-        // Given
-        val command = GetPoseCommand(userId = 1L, poseId = 10L)
-        val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
-        every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
-        every { poseViewCache.addViewer(10L, 1L) } throws RuntimeException("Redis 장애")
-
-        // When / Then
-        shouldThrow<RuntimeException> {
-            useCase.execute(command)
+        fun makePoseWithScrap(id: Long = 1L, mediaId: Long = 101L, scraped: Boolean = false): PoseWithScrap {
+            val pose = aPose(id = id, mediaId = mediaId)
+            pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+            return PoseWithScrap(pose = pose, isScraped = scraped)
         }
-        verify(exactly = 0) { poseRepository.incrementViewCount(any()) }
-    }
 
-    test("조회수 증가 후 mediaClient 예외 - side effect 발생, 결과 실패") {
-        // Given
-        val command = GetPoseCommand(userId = 1L, poseId = 10L)
-        val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
-        every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
-        every { poseViewCache.addViewer(10L, 1L) } returns true
-        every { poseRepository.incrementViewCount(10L) } returns Unit
-        every { mediaClient.getMediaStorageInfo(101L) } throws RuntimeException("미디어 조회 실패")
+        fun makeMediaStorageInfo(mediaId: Long = 101L): MediaStorageInfo = MediaStorageInfo(
+            mediaId = mediaId,
+            storageKey = "pose/image-$mediaId.jpg",
+            contentType = "image/jpeg",
+            width = 800,
+            height = 600,
+        )
 
-        // When / Then
-        shouldThrow<RuntimeException> {
-            useCase.execute(command)
+        test("신규 조회자 (cache miss) - addViewer=true → 조회수 증가 + 미디어 매핑") {
+            // Given
+            val command = GetPoseCommand(userId = 1L, poseId = 10L)
+            val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
+            every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
+            every { poseViewCache.addViewer(10L, 1L) } returns true // cache miss → 신규 조회자
+            every { poseRepository.incrementViewCount(10L) } returns Unit
+            every { mediaClient.getMediaStorageInfo(101L) } returns makeMediaStorageInfo(101L)
+
+            // When
+            val result = useCase.execute(command)
+
+            // Then
+            verify(exactly = 1) { poseRepository.incrementViewCount(10L) }
+            result.poseId shouldBe 10L
+            result.storageKey shouldBe "pose/image-101.jpg"
+            result.scrap shouldBe false
         }
-        // 조회수는 이미 증가됨 (side effect 발생)
-        verify(exactly = 1) { poseRepository.incrementViewCount(10L) }
-    }
-})
+
+        test("재방문자 (cache hit) - addViewer=false → 조회수 미증가") {
+            // Given
+            val command = GetPoseCommand(userId = 1L, poseId = 10L)
+            val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
+            every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
+            every { poseViewCache.addViewer(10L, 1L) } returns false // cache hit → 재방문자
+            every { mediaClient.getMediaStorageInfo(101L) } returns makeMediaStorageInfo(101L)
+
+            // When
+            val result = useCase.execute(command)
+
+            // Then
+            verify(exactly = 0) { poseRepository.incrementViewCount(any()) }
+            result.poseId shouldBe 10L
+        }
+
+        test("포즈 미존재 → BusinessException(NOT_FOUND)") {
+            // Given
+            val command = GetPoseCommand(userId = 1L, poseId = 999L)
+            every { poseRepository.getOwnedPoseWithScrap(1L, 999L) } returns null
+
+            // When / Then
+            val ex = shouldThrow<BusinessException> {
+                useCase.execute(command)
+            }
+            ex.resultCode shouldBe ResultCode.NOT_FOUND
+            verify(exactly = 0) { poseViewCache.addViewer(any(), any()) }
+            verify(exactly = 0) { mediaClient.getMediaStorageInfo(any()) }
+        }
+
+        test("addViewer 캐시 장애 → 예외 전파") {
+            // Given
+            val command = GetPoseCommand(userId = 1L, poseId = 10L)
+            val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
+            every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
+            every { poseViewCache.addViewer(10L, 1L) } throws RuntimeException("Redis 장애")
+
+            // When / Then
+            shouldThrow<RuntimeException> {
+                useCase.execute(command)
+            }
+            verify(exactly = 0) { poseRepository.incrementViewCount(any()) }
+        }
+
+        test("조회수 증가 후 mediaClient 예외 - side effect 발생, 결과 실패") {
+            // Given
+            val command = GetPoseCommand(userId = 1L, poseId = 10L)
+            val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
+            every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
+            every { poseViewCache.addViewer(10L, 1L) } returns true
+            every { poseRepository.incrementViewCount(10L) } returns Unit
+            every { mediaClient.getMediaStorageInfo(101L) } throws RuntimeException("미디어 조회 실패")
+
+            // When / Then
+            shouldThrow<RuntimeException> {
+                useCase.execute(command)
+            }
+            // 조회수는 이미 증가됨 (side effect 발생)
+            verify(exactly = 1) { poseRepository.incrementViewCount(10L) }
+        }
+    })

--- a/src/test/kotlin/com/neki/pose/application/usecase/GetPoseUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/GetPoseUseCaseTest.kt
@@ -11,121 +11,133 @@ import com.neki.pose.application.port.PoseViewCachePort
 import com.neki.testfixture.FakeTransactionRunner
 import com.neki.testfixture.aPose
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
-class GetPoseUseCaseTest :
-    FunSpec({
+class GetPoseUseCaseTest {
 
-        lateinit var poseRepository: PoseRepositoryPort
-        lateinit var mediaClient: MediaClientPort
-        lateinit var poseViewCache: PoseViewCachePort
-        lateinit var transactionRunner: FakeTransactionRunner
-        lateinit var useCase: GetPoseUseCase
+    private lateinit var poseRepository: PoseRepositoryPort
+    private lateinit var mediaClient: MediaClientPort
+    private lateinit var poseViewCache: PoseViewCachePort
+    private lateinit var transactionRunner: FakeTransactionRunner
+    private lateinit var useCase: GetPoseUseCase
 
-        beforeTest {
-            poseRepository = mockk()
-            mediaClient = mockk()
-            poseViewCache = mockk()
-            transactionRunner = FakeTransactionRunner()
-            useCase = GetPoseUseCase(poseRepository, mediaClient, poseViewCache, transactionRunner)
+    @BeforeEach
+    fun setUp() {
+        poseRepository = mockk()
+        mediaClient = mockk()
+        poseViewCache = mockk()
+        transactionRunner = FakeTransactionRunner()
+        useCase = GetPoseUseCase(poseRepository, mediaClient, poseViewCache, transactionRunner)
+    }
+
+    private fun makePoseWithScrap(id: Long = 1L, mediaId: Long = 101L, scraped: Boolean = false): PoseWithScrap {
+        val pose = aPose(id = id, mediaId = mediaId)
+        pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+        return PoseWithScrap(pose = pose, isScraped = scraped)
+    }
+
+    private fun makeMediaStorageInfo(mediaId: Long = 101L): MediaStorageInfo = MediaStorageInfo(
+        mediaId = mediaId,
+        storageKey = "pose/image-$mediaId.jpg",
+        contentType = "image/jpeg",
+        width = 800,
+        height = 600,
+    )
+
+    @Test
+    @DisplayName("신규 조회자 (cache miss) - addViewer=true → 조회수 증가 + 미디어 매핑")
+    fun `신규 조회자 (cache miss) - addViewer=true → 조회수 증가 + 미디어 매핑`() {
+        // Given
+        val command = GetPoseCommand(userId = 1L, poseId = 10L)
+        val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
+        every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
+        every { poseViewCache.addViewer(10L, 1L) } returns true // cache miss → 신규 조회자
+        every { poseRepository.incrementViewCount(10L) } returns Unit
+        every { mediaClient.getMediaStorageInfo(101L) } returns makeMediaStorageInfo(101L)
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        verify(exactly = 1) { poseRepository.incrementViewCount(10L) }
+        result.poseId shouldBe 10L
+        result.storageKey shouldBe "pose/image-101.jpg"
+        result.scrap shouldBe false
+    }
+
+    @Test
+    @DisplayName("재방문자 (cache hit) - addViewer=false → 조회수 미증가")
+    fun `재방문자 (cache hit) - addViewer=false → 조회수 미증가`() {
+        // Given
+        val command = GetPoseCommand(userId = 1L, poseId = 10L)
+        val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
+        every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
+        every { poseViewCache.addViewer(10L, 1L) } returns false // cache hit → 재방문자
+        every { mediaClient.getMediaStorageInfo(101L) } returns makeMediaStorageInfo(101L)
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        verify(exactly = 0) { poseRepository.incrementViewCount(any()) }
+        result.poseId shouldBe 10L
+    }
+
+    @Test
+    @DisplayName("포즈 미존재 → BusinessException(NOT_FOUND)")
+    fun `포즈 미존재 → BusinessException(NOT_FOUND)`() {
+        // Given
+        val command = GetPoseCommand(userId = 1L, poseId = 999L)
+        every { poseRepository.getOwnedPoseWithScrap(1L, 999L) } returns null
+
+        // When / Then
+        val ex = shouldThrow<BusinessException> {
+            useCase.execute(command)
         }
+        ex.resultCode shouldBe ResultCode.NOT_FOUND
+        verify(exactly = 0) { poseViewCache.addViewer(any(), any()) }
+        verify(exactly = 0) { mediaClient.getMediaStorageInfo(any()) }
+    }
 
-        fun makePoseWithScrap(id: Long = 1L, mediaId: Long = 101L, scraped: Boolean = false): PoseWithScrap {
-            val pose = aPose(id = id, mediaId = mediaId)
-            pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
-            return PoseWithScrap(pose = pose, isScraped = scraped)
+    @Test
+    @DisplayName("addViewer 캐시 장애 → 예외 전파")
+    fun `addViewer 캐시 장애 → 예외 전파`() {
+        // Given
+        val command = GetPoseCommand(userId = 1L, poseId = 10L)
+        val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
+        every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
+        every { poseViewCache.addViewer(10L, 1L) } throws RuntimeException("Redis 장애")
+
+        // When / Then
+        shouldThrow<RuntimeException> {
+            useCase.execute(command)
         }
+        verify(exactly = 0) { poseRepository.incrementViewCount(any()) }
+    }
 
-        fun makeMediaStorageInfo(mediaId: Long = 101L): MediaStorageInfo = MediaStorageInfo(
-            mediaId = mediaId,
-            storageKey = "pose/image-$mediaId.jpg",
-            contentType = "image/jpeg",
-            width = 800,
-            height = 600,
-        )
+    @Test
+    @DisplayName("조회수 증가 후 mediaClient 예외 - side effect 발생, 결과 실패")
+    fun `조회수 증가 후 mediaClient 예외 - side effect 발생, 결과 실패`() {
+        // Given
+        val command = GetPoseCommand(userId = 1L, poseId = 10L)
+        val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
+        every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
+        every { poseViewCache.addViewer(10L, 1L) } returns true
+        every { poseRepository.incrementViewCount(10L) } returns Unit
+        every { mediaClient.getMediaStorageInfo(101L) } throws RuntimeException("미디어 조회 실패")
 
-        test("신규 조회자 (cache miss) - addViewer=true → 조회수 증가 + 미디어 매핑") {
-            // Given
-            val command = GetPoseCommand(userId = 1L, poseId = 10L)
-            val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
-            every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
-            every { poseViewCache.addViewer(10L, 1L) } returns true // cache miss → 신규 조회자
-            every { poseRepository.incrementViewCount(10L) } returns Unit
-            every { mediaClient.getMediaStorageInfo(101L) } returns makeMediaStorageInfo(101L)
-
-            // When
-            val result = useCase.execute(command)
-
-            // Then
-            verify(exactly = 1) { poseRepository.incrementViewCount(10L) }
-            result.poseId shouldBe 10L
-            result.storageKey shouldBe "pose/image-101.jpg"
-            result.scrap shouldBe false
+        // When / Then
+        shouldThrow<RuntimeException> {
+            useCase.execute(command)
         }
-
-        test("재방문자 (cache hit) - addViewer=false → 조회수 미증가") {
-            // Given
-            val command = GetPoseCommand(userId = 1L, poseId = 10L)
-            val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
-            every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
-            every { poseViewCache.addViewer(10L, 1L) } returns false // cache hit → 재방문자
-            every { mediaClient.getMediaStorageInfo(101L) } returns makeMediaStorageInfo(101L)
-
-            // When
-            val result = useCase.execute(command)
-
-            // Then
-            verify(exactly = 0) { poseRepository.incrementViewCount(any()) }
-            result.poseId shouldBe 10L
-        }
-
-        test("포즈 미존재 → BusinessException(NOT_FOUND)") {
-            // Given
-            val command = GetPoseCommand(userId = 1L, poseId = 999L)
-            every { poseRepository.getOwnedPoseWithScrap(1L, 999L) } returns null
-
-            // When / Then
-            val ex = shouldThrow<BusinessException> {
-                useCase.execute(command)
-            }
-            ex.resultCode shouldBe ResultCode.NOT_FOUND
-            verify(exactly = 0) { poseViewCache.addViewer(any(), any()) }
-            verify(exactly = 0) { mediaClient.getMediaStorageInfo(any()) }
-        }
-
-        test("addViewer 캐시 장애 → 예외 전파") {
-            // Given
-            val command = GetPoseCommand(userId = 1L, poseId = 10L)
-            val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
-            every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
-            every { poseViewCache.addViewer(10L, 1L) } throws RuntimeException("Redis 장애")
-
-            // When / Then
-            shouldThrow<RuntimeException> {
-                useCase.execute(command)
-            }
-            verify(exactly = 0) { poseRepository.incrementViewCount(any()) }
-        }
-
-        test("조회수 증가 후 mediaClient 예외 - side effect 발생, 결과 실패") {
-            // Given
-            val command = GetPoseCommand(userId = 1L, poseId = 10L)
-            val poseWithScrap = makePoseWithScrap(id = 10L, mediaId = 101L)
-            every { poseRepository.getOwnedPoseWithScrap(1L, 10L) } returns poseWithScrap
-            every { poseViewCache.addViewer(10L, 1L) } returns true
-            every { poseRepository.incrementViewCount(10L) } returns Unit
-            every { mediaClient.getMediaStorageInfo(101L) } throws RuntimeException("미디어 조회 실패")
-
-            // When / Then
-            shouldThrow<RuntimeException> {
-                useCase.execute(command)
-            }
-            // 조회수는 이미 증가됨 (side effect 발생)
-            verify(exactly = 1) { poseRepository.incrementViewCount(10L) }
-        }
-    })
+        // 조회수는 이미 증가됨 (side effect 발생)
+        verify(exactly = 1) { poseRepository.incrementViewCount(10L) }
+    }
+}

--- a/src/test/kotlin/com/neki/pose/application/usecase/GetPosesUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/GetPosesUseCaseTest.kt
@@ -8,226 +8,240 @@ import com.neki.pose.application.port.MediaClientPort
 import com.neki.pose.application.port.PoseRepositoryPort
 import com.neki.testfixture.FakeTransactionRunner
 import com.neki.testfixture.aPose
-import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
-class GetPosesUseCaseTest :
-    FunSpec({
+class GetPosesUseCaseTest {
 
-        lateinit var poseRepository: PoseRepositoryPort
-        lateinit var mediaClient: MediaClientPort
-        lateinit var transactionRunner: FakeTransactionRunner
-        lateinit var useCase: GetPosesUseCase
+    private lateinit var poseRepository: PoseRepositoryPort
+    private lateinit var mediaClient: MediaClientPort
+    private lateinit var transactionRunner: FakeTransactionRunner
+    private lateinit var useCase: GetPosesUseCase
 
-        beforeTest {
-            poseRepository = mockk()
-            mediaClient = mockk()
-            transactionRunner = FakeTransactionRunner()
-            useCase = GetPosesUseCase(poseRepository, mediaClient, transactionRunner)
-        }
+    @BeforeEach
+    fun setUp() {
+        poseRepository = mockk()
+        mediaClient = mockk()
+        transactionRunner = FakeTransactionRunner()
+        useCase = GetPosesUseCase(poseRepository, mediaClient, transactionRunner)
+    }
 
-        fun makeCommand(page: Int = 0, size: Int = 10): GetPosesCommand = GetPosesCommand(
-            userId = 1L,
-            page = page,
-            size = size,
-            headCount = null,
-            sortOrder = SortOrder.DESC,
+    private fun makeCommand(page: Int = 0, size: Int = 10): GetPosesCommand = GetPosesCommand(
+        userId = 1L,
+        page = page,
+        size = size,
+        headCount = null,
+        sortOrder = SortOrder.DESC,
+    )
+
+    private fun makePoseWithScrap(id: Long, mediaId: Long, scrapped: Boolean = false): PoseWithScrap {
+        val pose = aPose(id = id, mediaId = mediaId)
+        pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+        return PoseWithScrap(pose = pose, isScraped = scrapped)
+    }
+
+    private fun makeMediaStorageInfo(mediaId: Long): MediaStorageInfo = MediaStorageInfo(
+        mediaId = mediaId,
+        storageKey = "pose/image-$mediaId.jpg",
+        contentType = "image/jpeg",
+        width = 800,
+        height = 600,
+    )
+
+    @Test
+    @DisplayName("정상 조회 + 미디어 매핑 - poses + storageInfo 반환")
+    fun `정상 조회 + 미디어 매핑 - poses + storageInfo 반환`() {
+        // Given
+        val command = makeCommand(size = 2)
+        val poseList = listOf(
+            makePoseWithScrap(id = 1L, mediaId = 101L, scrapped = false),
+            makePoseWithScrap(id = 2L, mediaId = 102L, scrapped = true),
+        )
+        every {
+            poseRepository.listPosesWithScrap(
+                userId = 1L,
+                offset = 0,
+                limit = 3,
+                headCount = null,
+                sortOrder = SortOrder.DESC,
+            )
+        } returns poseList
+
+        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
+            makeMediaStorageInfo(101L),
+            makeMediaStorageInfo(102L),
         )
 
-        fun makePoseWithScrap(id: Long, mediaId: Long, scrapped: Boolean = false): PoseWithScrap {
-            val pose = aPose(id = id, mediaId = mediaId)
-            pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
-            return PoseWithScrap(pose = pose, isScraped = scrapped)
-        }
+        // When
+        val result = useCase.execute(command)
 
-        fun makeMediaStorageInfo(mediaId: Long): MediaStorageInfo = MediaStorageInfo(
-            mediaId = mediaId,
-            storageKey = "pose/image-$mediaId.jpg",
-            contentType = "image/jpeg",
-            width = 800,
-            height = 600,
+        // Then
+        result.poses.size shouldBe 2
+        result.hasNext shouldBe false
+        result.poses[0].poseId shouldBe 1L
+        result.poses[0].storageKey shouldBe "pose/image-101.jpg"
+        result.poses[0].scrap shouldBe false
+        result.poses[1].poseId shouldBe 2L
+        result.poses[1].scrap shouldBe true
+    }
+
+    @Test
+    @DisplayName("hasNext=true - 다음 페이지 존재")
+    fun `hasNext=true - 다음 페이지 존재`() {
+        // Given
+        val command = makeCommand(size = 2)
+        // size+1 = 3개 조회됨 → hasNext true
+        val poseList = listOf(
+            makePoseWithScrap(id = 1L, mediaId = 101L),
+            makePoseWithScrap(id = 2L, mediaId = 102L),
+            makePoseWithScrap(id = 3L, mediaId = 103L),
+        )
+        every {
+            poseRepository.listPosesWithScrap(
+                userId = 1L,
+                offset = 0,
+                limit = 3,
+                headCount = null,
+                sortOrder = SortOrder.DESC,
+            )
+        } returns poseList
+
+        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
+            makeMediaStorageInfo(101L),
+            makeMediaStorageInfo(102L),
         )
 
-        test("정상 조회 + 미디어 매핑 - poses + storageInfo 반환") {
-            // Given
-            val command = makeCommand(size = 2)
-            val poseList = listOf(
-                makePoseWithScrap(id = 1L, mediaId = 101L, scrapped = false),
-                makePoseWithScrap(id = 2L, mediaId = 102L, scrapped = true),
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.hasNext shouldBe true
+        result.poses.size shouldBe 2
+    }
+
+    @Test
+    @DisplayName("hasNext=false - 마지막 페이지")
+    fun `hasNext=false - 마지막 페이지`() {
+        // Given
+        val command = makeCommand(size = 5)
+        // size+1 = 6개 조회하려 했지만 3개만 있음 → hasNext false
+        val poseList = listOf(
+            makePoseWithScrap(id = 1L, mediaId = 101L),
+            makePoseWithScrap(id = 2L, mediaId = 102L),
+            makePoseWithScrap(id = 3L, mediaId = 103L),
+        )
+        every {
+            poseRepository.listPosesWithScrap(
+                userId = 1L,
+                offset = 0,
+                limit = 6,
+                headCount = null,
+                sortOrder = SortOrder.DESC,
             )
-            every {
-                poseRepository.listPosesWithScrap(
-                    userId = 1L,
-                    offset = 0,
-                    limit = 3,
-                    headCount = null,
-                    sortOrder = SortOrder.DESC,
-                )
-            } returns poseList
+        } returns poseList
 
-            every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
-                makeMediaStorageInfo(101L),
-                makeMediaStorageInfo(102L),
+        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L, 103L)) } returns listOf(
+            makeMediaStorageInfo(101L),
+            makeMediaStorageInfo(102L),
+            makeMediaStorageInfo(103L),
+        )
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.hasNext shouldBe false
+        result.poses.size shouldBe 3
+    }
+
+    @Test
+    @DisplayName("빈 결과 - 빈 리스트와 hasNext=false 반환")
+    fun `빈 결과 - 빈 리스트와 hasNext=false 반환`() {
+        // Given
+        val command = makeCommand()
+        every {
+            poseRepository.listPosesWithScrap(
+                userId = 1L,
+                offset = 0,
+                limit = 11,
+                headCount = null,
+                sortOrder = SortOrder.DESC,
             )
+        } returns emptyList()
 
-            // When
-            val result = useCase.execute(command)
+        // When
+        val result = useCase.execute(command)
 
-            // Then
-            result.poses.size shouldBe 2
-            result.hasNext shouldBe false
-            result.poses[0].poseId shouldBe 1L
-            result.poses[0].storageKey shouldBe "pose/image-101.jpg"
-            result.poses[0].scrap shouldBe false
-            result.poses[1].poseId shouldBe 2L
-            result.poses[1].scrap shouldBe true
-        }
+        // Then
+        result.poses shouldBe emptyList()
+        result.hasNext shouldBe false
+    }
 
-        test("hasNext=true - 다음 페이지 존재") {
-            // Given
-            val command = makeCommand(size = 2)
-            // size+1 = 3개 조회됨 → hasNext true
-            val poseList = listOf(
-                makePoseWithScrap(id = 1L, mediaId = 101L),
-                makePoseWithScrap(id = 2L, mediaId = 102L),
-                makePoseWithScrap(id = 3L, mediaId = 103L),
+    @Test
+    @DisplayName("일부 미디어 미존재 - mapNotNull로 필터링하여 일부만 반환")
+    fun `일부 미디어 미존재 - mapNotNull로 필터링하여 일부만 반환`() {
+        // Given
+        val command = makeCommand(size = 3)
+        val poseList = listOf(
+            makePoseWithScrap(id = 1L, mediaId = 101L),
+            makePoseWithScrap(id = 2L, mediaId = 102L),
+            makePoseWithScrap(id = 3L, mediaId = 103L),
+        )
+        every {
+            poseRepository.listPosesWithScrap(
+                userId = 1L,
+                offset = 0,
+                limit = 4,
+                headCount = null,
+                sortOrder = SortOrder.DESC,
             )
-            every {
-                poseRepository.listPosesWithScrap(
-                    userId = 1L,
-                    offset = 0,
-                    limit = 3,
-                    headCount = null,
-                    sortOrder = SortOrder.DESC,
-                )
-            } returns poseList
+        } returns poseList
 
-            every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
-                makeMediaStorageInfo(101L),
-                makeMediaStorageInfo(102L),
+        // mediaId=102L은 미존재
+        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L, 103L)) } returns listOf(
+            makeMediaStorageInfo(101L),
+            makeMediaStorageInfo(103L),
+        )
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.poses.size shouldBe 2
+        result.poses.map { it.poseId } shouldBe listOf(1L, 3L)
+    }
+
+    @Test
+    @DisplayName("전체 미디어 미존재 - 빈 리스트 반환")
+    fun `전체 미디어 미존재 - 빈 리스트 반환`() {
+        // Given
+        val command = makeCommand(size = 2)
+        val poseList = listOf(
+            makePoseWithScrap(id = 1L, mediaId = 101L),
+            makePoseWithScrap(id = 2L, mediaId = 102L),
+        )
+        every {
+            poseRepository.listPosesWithScrap(
+                userId = 1L,
+                offset = 0,
+                limit = 3,
+                headCount = null,
+                sortOrder = SortOrder.DESC,
             )
+        } returns poseList
 
-            // When
-            val result = useCase.execute(command)
+        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns emptyList()
 
-            // Then
-            result.hasNext shouldBe true
-            result.poses.size shouldBe 2
-        }
+        // When
+        val result = useCase.execute(command)
 
-        test("hasNext=false - 마지막 페이지") {
-            // Given
-            val command = makeCommand(size = 5)
-            // size+1 = 6개 조회하려 했지만 3개만 있음 → hasNext false
-            val poseList = listOf(
-                makePoseWithScrap(id = 1L, mediaId = 101L),
-                makePoseWithScrap(id = 2L, mediaId = 102L),
-                makePoseWithScrap(id = 3L, mediaId = 103L),
-            )
-            every {
-                poseRepository.listPosesWithScrap(
-                    userId = 1L,
-                    offset = 0,
-                    limit = 6,
-                    headCount = null,
-                    sortOrder = SortOrder.DESC,
-                )
-            } returns poseList
-
-            every { mediaClient.getMediaStorageInfos(listOf(101L, 102L, 103L)) } returns listOf(
-                makeMediaStorageInfo(101L),
-                makeMediaStorageInfo(102L),
-                makeMediaStorageInfo(103L),
-            )
-
-            // When
-            val result = useCase.execute(command)
-
-            // Then
-            result.hasNext shouldBe false
-            result.poses.size shouldBe 3
-        }
-
-        test("빈 결과 - 빈 리스트와 hasNext=false 반환") {
-            // Given
-            val command = makeCommand()
-            every {
-                poseRepository.listPosesWithScrap(
-                    userId = 1L,
-                    offset = 0,
-                    limit = 11,
-                    headCount = null,
-                    sortOrder = SortOrder.DESC,
-                )
-            } returns emptyList()
-
-            // When
-            val result = useCase.execute(command)
-
-            // Then
-            result.poses shouldBe emptyList()
-            result.hasNext shouldBe false
-        }
-
-        test("일부 미디어 미존재 - mapNotNull로 필터링하여 일부만 반환") {
-            // Given
-            val command = makeCommand(size = 3)
-            val poseList = listOf(
-                makePoseWithScrap(id = 1L, mediaId = 101L),
-                makePoseWithScrap(id = 2L, mediaId = 102L),
-                makePoseWithScrap(id = 3L, mediaId = 103L),
-            )
-            every {
-                poseRepository.listPosesWithScrap(
-                    userId = 1L,
-                    offset = 0,
-                    limit = 4,
-                    headCount = null,
-                    sortOrder = SortOrder.DESC,
-                )
-            } returns poseList
-
-            // mediaId=102L은 미존재
-            every { mediaClient.getMediaStorageInfos(listOf(101L, 102L, 103L)) } returns listOf(
-                makeMediaStorageInfo(101L),
-                makeMediaStorageInfo(103L),
-            )
-
-            // When
-            val result = useCase.execute(command)
-
-            // Then
-            result.poses.size shouldBe 2
-            result.poses.map { it.poseId } shouldBe listOf(1L, 3L)
-        }
-
-        test("전체 미디어 미존재 - 빈 리스트 반환") {
-            // Given
-            val command = makeCommand(size = 2)
-            val poseList = listOf(
-                makePoseWithScrap(id = 1L, mediaId = 101L),
-                makePoseWithScrap(id = 2L, mediaId = 102L),
-            )
-            every {
-                poseRepository.listPosesWithScrap(
-                    userId = 1L,
-                    offset = 0,
-                    limit = 3,
-                    headCount = null,
-                    sortOrder = SortOrder.DESC,
-                )
-            } returns poseList
-
-            every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns emptyList()
-
-            // When
-            val result = useCase.execute(command)
-
-            // Then
-            result.poses shouldBe emptyList()
-            result.hasNext shouldBe false
-        }
-    })
+        // Then
+        result.poses shouldBe emptyList()
+        result.hasNext shouldBe false
+    }
+}

--- a/src/test/kotlin/com/neki/pose/application/usecase/GetPosesUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/GetPosesUseCaseTest.kt
@@ -6,7 +6,6 @@ import com.neki.pose.application.contract.MediaStorageInfo
 import com.neki.pose.application.contract.PoseWithScrap
 import com.neki.pose.application.port.MediaClientPort
 import com.neki.pose.application.port.PoseRepositoryPort
-import com.neki.pose.domain.HeadCount
 import com.neki.testfixture.FakeTransactionRunner
 import com.neki.testfixture.aPose
 import io.kotest.core.spec.style.FunSpec
@@ -15,201 +14,220 @@ import io.mockk.every
 import io.mockk.mockk
 import java.time.LocalDateTime
 
-class GetPosesUseCaseTest : FunSpec({
+class GetPosesUseCaseTest :
+    FunSpec({
 
-    lateinit var poseRepository: PoseRepositoryPort
-    lateinit var mediaClient: MediaClientPort
-    lateinit var transactionRunner: FakeTransactionRunner
-    lateinit var useCase: GetPosesUseCase
+        lateinit var poseRepository: PoseRepositoryPort
+        lateinit var mediaClient: MediaClientPort
+        lateinit var transactionRunner: FakeTransactionRunner
+        lateinit var useCase: GetPosesUseCase
 
-    beforeTest {
-        poseRepository = mockk()
-        mediaClient = mockk()
-        transactionRunner = FakeTransactionRunner()
-        useCase = GetPosesUseCase(poseRepository, mediaClient, transactionRunner)
-    }
+        beforeTest {
+            poseRepository = mockk()
+            mediaClient = mockk()
+            transactionRunner = FakeTransactionRunner()
+            useCase = GetPosesUseCase(poseRepository, mediaClient, transactionRunner)
+        }
 
-    fun makeCommand(page: Int = 0, size: Int = 10): GetPosesCommand = GetPosesCommand(
-        userId = 1L,
-        page = page,
-        size = size,
-        headCount = null,
-        sortOrder = SortOrder.DESC,
-    )
-
-    fun makePoseWithScrap(id: Long, mediaId: Long, scrapped: Boolean = false): PoseWithScrap {
-        val pose = aPose(id = id, mediaId = mediaId)
-        pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
-        return PoseWithScrap(pose = pose, isScraped = scrapped)
-    }
-
-    fun makeMediaStorageInfo(mediaId: Long): MediaStorageInfo = MediaStorageInfo(
-        mediaId = mediaId,
-        storageKey = "pose/image-$mediaId.jpg",
-        contentType = "image/jpeg",
-        width = 800,
-        height = 600,
-    )
-
-    test("정상 조회 + 미디어 매핑 - poses + storageInfo 반환") {
-        // Given
-        val command = makeCommand(size = 2)
-        val poseList = listOf(
-            makePoseWithScrap(id = 1L, mediaId = 101L, scrapped = false),
-            makePoseWithScrap(id = 2L, mediaId = 102L, scrapped = true),
+        fun makeCommand(page: Int = 0, size: Int = 10): GetPosesCommand = GetPosesCommand(
+            userId = 1L,
+            page = page,
+            size = size,
+            headCount = null,
+            sortOrder = SortOrder.DESC,
         )
-        every {
-            poseRepository.listPosesWithScrap(
-                userId = 1L, offset = 0, limit = 3,
-                headCount = null, sortOrder = SortOrder.DESC,
+
+        fun makePoseWithScrap(id: Long, mediaId: Long, scrapped: Boolean = false): PoseWithScrap {
+            val pose = aPose(id = id, mediaId = mediaId)
+            pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+            return PoseWithScrap(pose = pose, isScraped = scrapped)
+        }
+
+        fun makeMediaStorageInfo(mediaId: Long): MediaStorageInfo = MediaStorageInfo(
+            mediaId = mediaId,
+            storageKey = "pose/image-$mediaId.jpg",
+            contentType = "image/jpeg",
+            width = 800,
+            height = 600,
+        )
+
+        test("정상 조회 + 미디어 매핑 - poses + storageInfo 반환") {
+            // Given
+            val command = makeCommand(size = 2)
+            val poseList = listOf(
+                makePoseWithScrap(id = 1L, mediaId = 101L, scrapped = false),
+                makePoseWithScrap(id = 2L, mediaId = 102L, scrapped = true),
             )
-        } returns poseList
+            every {
+                poseRepository.listPosesWithScrap(
+                    userId = 1L,
+                    offset = 0,
+                    limit = 3,
+                    headCount = null,
+                    sortOrder = SortOrder.DESC,
+                )
+            } returns poseList
 
-        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
-            makeMediaStorageInfo(101L),
-            makeMediaStorageInfo(102L),
-        )
-
-        // When
-        val result = useCase.execute(command)
-
-        // Then
-        result.poses.size shouldBe 2
-        result.hasNext shouldBe false
-        result.poses[0].poseId shouldBe 1L
-        result.poses[0].storageKey shouldBe "pose/image-101.jpg"
-        result.poses[0].scrap shouldBe false
-        result.poses[1].poseId shouldBe 2L
-        result.poses[1].scrap shouldBe true
-    }
-
-    test("hasNext=true - 다음 페이지 존재") {
-        // Given
-        val command = makeCommand(size = 2)
-        // size+1 = 3개 조회됨 → hasNext true
-        val poseList = listOf(
-            makePoseWithScrap(id = 1L, mediaId = 101L),
-            makePoseWithScrap(id = 2L, mediaId = 102L),
-            makePoseWithScrap(id = 3L, mediaId = 103L),
-        )
-        every {
-            poseRepository.listPosesWithScrap(
-                userId = 1L, offset = 0, limit = 3,
-                headCount = null, sortOrder = SortOrder.DESC,
+            every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
+                makeMediaStorageInfo(101L),
+                makeMediaStorageInfo(102L),
             )
-        } returns poseList
 
-        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
-            makeMediaStorageInfo(101L),
-            makeMediaStorageInfo(102L),
-        )
+            // When
+            val result = useCase.execute(command)
 
-        // When
-        val result = useCase.execute(command)
+            // Then
+            result.poses.size shouldBe 2
+            result.hasNext shouldBe false
+            result.poses[0].poseId shouldBe 1L
+            result.poses[0].storageKey shouldBe "pose/image-101.jpg"
+            result.poses[0].scrap shouldBe false
+            result.poses[1].poseId shouldBe 2L
+            result.poses[1].scrap shouldBe true
+        }
 
-        // Then
-        result.hasNext shouldBe true
-        result.poses.size shouldBe 2
-    }
-
-    test("hasNext=false - 마지막 페이지") {
-        // Given
-        val command = makeCommand(size = 5)
-        // size+1 = 6개 조회하려 했지만 3개만 있음 → hasNext false
-        val poseList = listOf(
-            makePoseWithScrap(id = 1L, mediaId = 101L),
-            makePoseWithScrap(id = 2L, mediaId = 102L),
-            makePoseWithScrap(id = 3L, mediaId = 103L),
-        )
-        every {
-            poseRepository.listPosesWithScrap(
-                userId = 1L, offset = 0, limit = 6,
-                headCount = null, sortOrder = SortOrder.DESC,
+        test("hasNext=true - 다음 페이지 존재") {
+            // Given
+            val command = makeCommand(size = 2)
+            // size+1 = 3개 조회됨 → hasNext true
+            val poseList = listOf(
+                makePoseWithScrap(id = 1L, mediaId = 101L),
+                makePoseWithScrap(id = 2L, mediaId = 102L),
+                makePoseWithScrap(id = 3L, mediaId = 103L),
             )
-        } returns poseList
+            every {
+                poseRepository.listPosesWithScrap(
+                    userId = 1L,
+                    offset = 0,
+                    limit = 3,
+                    headCount = null,
+                    sortOrder = SortOrder.DESC,
+                )
+            } returns poseList
 
-        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L, 103L)) } returns listOf(
-            makeMediaStorageInfo(101L),
-            makeMediaStorageInfo(102L),
-            makeMediaStorageInfo(103L),
-        )
-
-        // When
-        val result = useCase.execute(command)
-
-        // Then
-        result.hasNext shouldBe false
-        result.poses.size shouldBe 3
-    }
-
-    test("빈 결과 - 빈 리스트와 hasNext=false 반환") {
-        // Given
-        val command = makeCommand()
-        every {
-            poseRepository.listPosesWithScrap(
-                userId = 1L, offset = 0, limit = 11,
-                headCount = null, sortOrder = SortOrder.DESC,
+            every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
+                makeMediaStorageInfo(101L),
+                makeMediaStorageInfo(102L),
             )
-        } returns emptyList()
 
-        // When
-        val result = useCase.execute(command)
+            // When
+            val result = useCase.execute(command)
 
-        // Then
-        result.poses shouldBe emptyList()
-        result.hasNext shouldBe false
-    }
+            // Then
+            result.hasNext shouldBe true
+            result.poses.size shouldBe 2
+        }
 
-    test("일부 미디어 미존재 - mapNotNull로 필터링하여 일부만 반환") {
-        // Given
-        val command = makeCommand(size = 3)
-        val poseList = listOf(
-            makePoseWithScrap(id = 1L, mediaId = 101L),
-            makePoseWithScrap(id = 2L, mediaId = 102L),
-            makePoseWithScrap(id = 3L, mediaId = 103L),
-        )
-        every {
-            poseRepository.listPosesWithScrap(
-                userId = 1L, offset = 0, limit = 4,
-                headCount = null, sortOrder = SortOrder.DESC,
+        test("hasNext=false - 마지막 페이지") {
+            // Given
+            val command = makeCommand(size = 5)
+            // size+1 = 6개 조회하려 했지만 3개만 있음 → hasNext false
+            val poseList = listOf(
+                makePoseWithScrap(id = 1L, mediaId = 101L),
+                makePoseWithScrap(id = 2L, mediaId = 102L),
+                makePoseWithScrap(id = 3L, mediaId = 103L),
             )
-        } returns poseList
+            every {
+                poseRepository.listPosesWithScrap(
+                    userId = 1L,
+                    offset = 0,
+                    limit = 6,
+                    headCount = null,
+                    sortOrder = SortOrder.DESC,
+                )
+            } returns poseList
 
-        // mediaId=102L은 미존재
-        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L, 103L)) } returns listOf(
-            makeMediaStorageInfo(101L),
-            makeMediaStorageInfo(103L),
-        )
-
-        // When
-        val result = useCase.execute(command)
-
-        // Then
-        result.poses.size shouldBe 2
-        result.poses.map { it.poseId } shouldBe listOf(1L, 3L)
-    }
-
-    test("전체 미디어 미존재 - 빈 리스트 반환") {
-        // Given
-        val command = makeCommand(size = 2)
-        val poseList = listOf(
-            makePoseWithScrap(id = 1L, mediaId = 101L),
-            makePoseWithScrap(id = 2L, mediaId = 102L),
-        )
-        every {
-            poseRepository.listPosesWithScrap(
-                userId = 1L, offset = 0, limit = 3,
-                headCount = null, sortOrder = SortOrder.DESC,
+            every { mediaClient.getMediaStorageInfos(listOf(101L, 102L, 103L)) } returns listOf(
+                makeMediaStorageInfo(101L),
+                makeMediaStorageInfo(102L),
+                makeMediaStorageInfo(103L),
             )
-        } returns poseList
 
-        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns emptyList()
+            // When
+            val result = useCase.execute(command)
 
-        // When
-        val result = useCase.execute(command)
+            // Then
+            result.hasNext shouldBe false
+            result.poses.size shouldBe 3
+        }
 
-        // Then
-        result.poses shouldBe emptyList()
-        result.hasNext shouldBe false
-    }
-})
+        test("빈 결과 - 빈 리스트와 hasNext=false 반환") {
+            // Given
+            val command = makeCommand()
+            every {
+                poseRepository.listPosesWithScrap(
+                    userId = 1L,
+                    offset = 0,
+                    limit = 11,
+                    headCount = null,
+                    sortOrder = SortOrder.DESC,
+                )
+            } returns emptyList()
+
+            // When
+            val result = useCase.execute(command)
+
+            // Then
+            result.poses shouldBe emptyList()
+            result.hasNext shouldBe false
+        }
+
+        test("일부 미디어 미존재 - mapNotNull로 필터링하여 일부만 반환") {
+            // Given
+            val command = makeCommand(size = 3)
+            val poseList = listOf(
+                makePoseWithScrap(id = 1L, mediaId = 101L),
+                makePoseWithScrap(id = 2L, mediaId = 102L),
+                makePoseWithScrap(id = 3L, mediaId = 103L),
+            )
+            every {
+                poseRepository.listPosesWithScrap(
+                    userId = 1L,
+                    offset = 0,
+                    limit = 4,
+                    headCount = null,
+                    sortOrder = SortOrder.DESC,
+                )
+            } returns poseList
+
+            // mediaId=102L은 미존재
+            every { mediaClient.getMediaStorageInfos(listOf(101L, 102L, 103L)) } returns listOf(
+                makeMediaStorageInfo(101L),
+                makeMediaStorageInfo(103L),
+            )
+
+            // When
+            val result = useCase.execute(command)
+
+            // Then
+            result.poses.size shouldBe 2
+            result.poses.map { it.poseId } shouldBe listOf(1L, 3L)
+        }
+
+        test("전체 미디어 미존재 - 빈 리스트 반환") {
+            // Given
+            val command = makeCommand(size = 2)
+            val poseList = listOf(
+                makePoseWithScrap(id = 1L, mediaId = 101L),
+                makePoseWithScrap(id = 2L, mediaId = 102L),
+            )
+            every {
+                poseRepository.listPosesWithScrap(
+                    userId = 1L,
+                    offset = 0,
+                    limit = 3,
+                    headCount = null,
+                    sortOrder = SortOrder.DESC,
+                )
+            } returns poseList
+
+            every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns emptyList()
+
+            // When
+            val result = useCase.execute(command)
+
+            // Then
+            result.poses shouldBe emptyList()
+            result.hasNext shouldBe false
+        }
+    })

--- a/src/test/kotlin/com/neki/pose/application/usecase/GetPosesUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/GetPosesUseCaseTest.kt
@@ -1,0 +1,215 @@
+package com.neki.pose.application.usecase
+
+import com.neki.common.domain.vo.SortOrder
+import com.neki.pose.application.command.GetPosesCommand
+import com.neki.pose.application.contract.MediaStorageInfo
+import com.neki.pose.application.contract.PoseWithScrap
+import com.neki.pose.application.port.MediaClientPort
+import com.neki.pose.application.port.PoseRepositoryPort
+import com.neki.pose.domain.HeadCount
+import com.neki.testfixture.FakeTransactionRunner
+import com.neki.testfixture.aPose
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDateTime
+
+class GetPosesUseCaseTest : FunSpec({
+
+    lateinit var poseRepository: PoseRepositoryPort
+    lateinit var mediaClient: MediaClientPort
+    lateinit var transactionRunner: FakeTransactionRunner
+    lateinit var useCase: GetPosesUseCase
+
+    beforeTest {
+        poseRepository = mockk()
+        mediaClient = mockk()
+        transactionRunner = FakeTransactionRunner()
+        useCase = GetPosesUseCase(poseRepository, mediaClient, transactionRunner)
+    }
+
+    fun makeCommand(page: Int = 0, size: Int = 10): GetPosesCommand = GetPosesCommand(
+        userId = 1L,
+        page = page,
+        size = size,
+        headCount = null,
+        sortOrder = SortOrder.DESC,
+    )
+
+    fun makePoseWithScrap(id: Long, mediaId: Long, scrapped: Boolean = false): PoseWithScrap {
+        val pose = aPose(id = id, mediaId = mediaId)
+        pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+        return PoseWithScrap(pose = pose, isScraped = scrapped)
+    }
+
+    fun makeMediaStorageInfo(mediaId: Long): MediaStorageInfo = MediaStorageInfo(
+        mediaId = mediaId,
+        storageKey = "pose/image-$mediaId.jpg",
+        contentType = "image/jpeg",
+        width = 800,
+        height = 600,
+    )
+
+    test("정상 조회 + 미디어 매핑 - poses + storageInfo 반환") {
+        // Given
+        val command = makeCommand(size = 2)
+        val poseList = listOf(
+            makePoseWithScrap(id = 1L, mediaId = 101L, scrapped = false),
+            makePoseWithScrap(id = 2L, mediaId = 102L, scrapped = true),
+        )
+        every {
+            poseRepository.listPosesWithScrap(
+                userId = 1L, offset = 0, limit = 3,
+                headCount = null, sortOrder = SortOrder.DESC,
+            )
+        } returns poseList
+
+        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
+            makeMediaStorageInfo(101L),
+            makeMediaStorageInfo(102L),
+        )
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.poses.size shouldBe 2
+        result.hasNext shouldBe false
+        result.poses[0].poseId shouldBe 1L
+        result.poses[0].storageKey shouldBe "pose/image-101.jpg"
+        result.poses[0].scrap shouldBe false
+        result.poses[1].poseId shouldBe 2L
+        result.poses[1].scrap shouldBe true
+    }
+
+    test("hasNext=true - 다음 페이지 존재") {
+        // Given
+        val command = makeCommand(size = 2)
+        // size+1 = 3개 조회됨 → hasNext true
+        val poseList = listOf(
+            makePoseWithScrap(id = 1L, mediaId = 101L),
+            makePoseWithScrap(id = 2L, mediaId = 102L),
+            makePoseWithScrap(id = 3L, mediaId = 103L),
+        )
+        every {
+            poseRepository.listPosesWithScrap(
+                userId = 1L, offset = 0, limit = 3,
+                headCount = null, sortOrder = SortOrder.DESC,
+            )
+        } returns poseList
+
+        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
+            makeMediaStorageInfo(101L),
+            makeMediaStorageInfo(102L),
+        )
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.hasNext shouldBe true
+        result.poses.size shouldBe 2
+    }
+
+    test("hasNext=false - 마지막 페이지") {
+        // Given
+        val command = makeCommand(size = 5)
+        // size+1 = 6개 조회하려 했지만 3개만 있음 → hasNext false
+        val poseList = listOf(
+            makePoseWithScrap(id = 1L, mediaId = 101L),
+            makePoseWithScrap(id = 2L, mediaId = 102L),
+            makePoseWithScrap(id = 3L, mediaId = 103L),
+        )
+        every {
+            poseRepository.listPosesWithScrap(
+                userId = 1L, offset = 0, limit = 6,
+                headCount = null, sortOrder = SortOrder.DESC,
+            )
+        } returns poseList
+
+        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L, 103L)) } returns listOf(
+            makeMediaStorageInfo(101L),
+            makeMediaStorageInfo(102L),
+            makeMediaStorageInfo(103L),
+        )
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.hasNext shouldBe false
+        result.poses.size shouldBe 3
+    }
+
+    test("빈 결과 - 빈 리스트와 hasNext=false 반환") {
+        // Given
+        val command = makeCommand()
+        every {
+            poseRepository.listPosesWithScrap(
+                userId = 1L, offset = 0, limit = 11,
+                headCount = null, sortOrder = SortOrder.DESC,
+            )
+        } returns emptyList()
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.poses shouldBe emptyList()
+        result.hasNext shouldBe false
+    }
+
+    test("일부 미디어 미존재 - mapNotNull로 필터링하여 일부만 반환") {
+        // Given
+        val command = makeCommand(size = 3)
+        val poseList = listOf(
+            makePoseWithScrap(id = 1L, mediaId = 101L),
+            makePoseWithScrap(id = 2L, mediaId = 102L),
+            makePoseWithScrap(id = 3L, mediaId = 103L),
+        )
+        every {
+            poseRepository.listPosesWithScrap(
+                userId = 1L, offset = 0, limit = 4,
+                headCount = null, sortOrder = SortOrder.DESC,
+            )
+        } returns poseList
+
+        // mediaId=102L은 미존재
+        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L, 103L)) } returns listOf(
+            makeMediaStorageInfo(101L),
+            makeMediaStorageInfo(103L),
+        )
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.poses.size shouldBe 2
+        result.poses.map { it.poseId } shouldBe listOf(1L, 3L)
+    }
+
+    test("전체 미디어 미존재 - 빈 리스트 반환") {
+        // Given
+        val command = makeCommand(size = 2)
+        val poseList = listOf(
+            makePoseWithScrap(id = 1L, mediaId = 101L),
+            makePoseWithScrap(id = 2L, mediaId = 102L),
+        )
+        every {
+            poseRepository.listPosesWithScrap(
+                userId = 1L, offset = 0, limit = 3,
+                headCount = null, sortOrder = SortOrder.DESC,
+            )
+        } returns poseList
+
+        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns emptyList()
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.poses shouldBe emptyList()
+        result.hasNext shouldBe false
+    }
+})

--- a/src/test/kotlin/com/neki/pose/application/usecase/GetScrapPosesUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/GetScrapPosesUseCaseTest.kt
@@ -1,0 +1,149 @@
+package com.neki.pose.application.usecase
+
+import com.neki.common.domain.vo.SortOrder
+import com.neki.pose.application.command.GetScrapPosesCommand
+import com.neki.pose.application.contract.MediaStorageInfo
+import com.neki.pose.application.port.MediaClientPort
+import com.neki.pose.application.port.PoseRepositoryPort
+import com.neki.pose.domain.entity.Pose
+import com.neki.testfixture.FakeTransactionRunner
+import com.neki.testfixture.aPose
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDateTime
+
+class GetScrapPosesUseCaseTest : FunSpec({
+
+    lateinit var poseRepository: PoseRepositoryPort
+    lateinit var mediaClient: MediaClientPort
+    lateinit var transactionRunner: FakeTransactionRunner
+    lateinit var useCase: GetScrapPosesUseCase
+
+    beforeTest {
+        poseRepository = mockk()
+        mediaClient = mockk()
+        transactionRunner = FakeTransactionRunner()
+        useCase = GetScrapPosesUseCase(poseRepository, mediaClient, transactionRunner)
+    }
+
+    fun makeCommand(page: Int = 0, size: Int = 10): GetScrapPosesCommand = GetScrapPosesCommand(
+        userId = 1L,
+        page = page,
+        size = size,
+        headCount = null,
+        sortOrder = SortOrder.DESC,
+    )
+
+    fun makePose(id: Long, mediaId: Long): Pose {
+        val pose = aPose(id = id, mediaId = mediaId)
+        pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+        return pose
+    }
+
+    fun makeMediaStorageInfo(mediaId: Long): MediaStorageInfo = MediaStorageInfo(
+        mediaId = mediaId,
+        storageKey = "pose/image-$mediaId.jpg",
+        contentType = "image/jpeg",
+        width = 800,
+        height = 600,
+    )
+
+    test("정상 조회 + 미디어 매핑 - poses + storageInfo 반환") {
+        // Given
+        val command = makeCommand(size = 2)
+        val poseList = listOf(makePose(1L, 101L), makePose(2L, 102L))
+
+        every {
+            poseRepository.listOwnedScrapPoses(
+                userId = 1L, offset = 0, limit = 3, sortOrder = SortOrder.DESC,
+            )
+        } returns poseList
+
+        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
+            makeMediaStorageInfo(101L),
+            makeMediaStorageInfo(102L),
+        )
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.poses.size shouldBe 2
+        result.hasNext shouldBe false
+        result.poses[0].poseId shouldBe 1L
+        result.poses[0].scrap shouldBe true
+        result.poses[0].storageKey shouldBe "pose/image-101.jpg"
+        result.poses[1].poseId shouldBe 2L
+    }
+
+    test("hasNext=true - 다음 페이지 존재") {
+        // Given
+        val command = makeCommand(size = 2)
+        // size+1 = 3개 조회됨 → hasNext true
+        val poseList = listOf(
+            makePose(1L, 101L),
+            makePose(2L, 102L),
+            makePose(3L, 103L),
+        )
+        every {
+            poseRepository.listOwnedScrapPoses(
+                userId = 1L, offset = 0, limit = 3, sortOrder = SortOrder.DESC,
+            )
+        } returns poseList
+
+        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
+            makeMediaStorageInfo(101L),
+            makeMediaStorageInfo(102L),
+        )
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.hasNext shouldBe true
+        result.poses.size shouldBe 2
+    }
+
+    test("hasNext=false - 마지막 페이지") {
+        // Given
+        val command = makeCommand(size = 5)
+        val poseList = listOf(makePose(1L, 101L), makePose(2L, 102L))
+
+        every {
+            poseRepository.listOwnedScrapPoses(
+                userId = 1L, offset = 0, limit = 6, sortOrder = SortOrder.DESC,
+            )
+        } returns poseList
+
+        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
+            makeMediaStorageInfo(101L),
+            makeMediaStorageInfo(102L),
+        )
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.hasNext shouldBe false
+        result.poses.size shouldBe 2
+    }
+
+    test("빈 결과 - 빈 리스트와 hasNext=false 반환") {
+        // Given
+        val command = makeCommand()
+        every {
+            poseRepository.listOwnedScrapPoses(
+                userId = 1L, offset = 0, limit = 11, sortOrder = SortOrder.DESC,
+            )
+        } returns emptyList()
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.poses shouldBe emptyList()
+        result.hasNext shouldBe false
+    }
+})

--- a/src/test/kotlin/com/neki/pose/application/usecase/GetScrapPosesUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/GetScrapPosesUseCaseTest.kt
@@ -8,155 +8,165 @@ import com.neki.pose.application.port.PoseRepositoryPort
 import com.neki.pose.domain.entity.Pose
 import com.neki.testfixture.FakeTransactionRunner
 import com.neki.testfixture.aPose
-import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
-class GetScrapPosesUseCaseTest :
-    FunSpec({
+class GetScrapPosesUseCaseTest {
 
-        lateinit var poseRepository: PoseRepositoryPort
-        lateinit var mediaClient: MediaClientPort
-        lateinit var transactionRunner: FakeTransactionRunner
-        lateinit var useCase: GetScrapPosesUseCase
+    private lateinit var poseRepository: PoseRepositoryPort
+    private lateinit var mediaClient: MediaClientPort
+    private lateinit var transactionRunner: FakeTransactionRunner
+    private lateinit var useCase: GetScrapPosesUseCase
 
-        beforeTest {
-            poseRepository = mockk()
-            mediaClient = mockk()
-            transactionRunner = FakeTransactionRunner()
-            useCase = GetScrapPosesUseCase(poseRepository, mediaClient, transactionRunner)
-        }
+    @BeforeEach
+    fun setUp() {
+        poseRepository = mockk()
+        mediaClient = mockk()
+        transactionRunner = FakeTransactionRunner()
+        useCase = GetScrapPosesUseCase(poseRepository, mediaClient, transactionRunner)
+    }
 
-        fun makeCommand(page: Int = 0, size: Int = 10): GetScrapPosesCommand = GetScrapPosesCommand(
-            userId = 1L,
-            page = page,
-            size = size,
-            headCount = null,
-            sortOrder = SortOrder.DESC,
+    private fun makeCommand(page: Int = 0, size: Int = 10): GetScrapPosesCommand = GetScrapPosesCommand(
+        userId = 1L,
+        page = page,
+        size = size,
+        headCount = null,
+        sortOrder = SortOrder.DESC,
+    )
+
+    private fun makePose(id: Long, mediaId: Long): Pose {
+        val pose = aPose(id = id, mediaId = mediaId)
+        pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+        return pose
+    }
+
+    private fun makeMediaStorageInfo(mediaId: Long): MediaStorageInfo = MediaStorageInfo(
+        mediaId = mediaId,
+        storageKey = "pose/image-$mediaId.jpg",
+        contentType = "image/jpeg",
+        width = 800,
+        height = 600,
+    )
+
+    @Test
+    @DisplayName("정상 조회 + 미디어 매핑 - poses + storageInfo 반환")
+    fun `정상 조회 + 미디어 매핑 - poses + storageInfo 반환`() {
+        // Given
+        val command = makeCommand(size = 2)
+        val poseList = listOf(makePose(1L, 101L), makePose(2L, 102L))
+
+        every {
+            poseRepository.listOwnedScrapPoses(
+                userId = 1L,
+                offset = 0,
+                limit = 3,
+                sortOrder = SortOrder.DESC,
+            )
+        } returns poseList
+
+        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
+            makeMediaStorageInfo(101L),
+            makeMediaStorageInfo(102L),
         )
 
-        fun makePose(id: Long, mediaId: Long): Pose {
-            val pose = aPose(id = id, mediaId = mediaId)
-            pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
-            return pose
-        }
+        // When
+        val result = useCase.execute(command)
 
-        fun makeMediaStorageInfo(mediaId: Long): MediaStorageInfo = MediaStorageInfo(
-            mediaId = mediaId,
-            storageKey = "pose/image-$mediaId.jpg",
-            contentType = "image/jpeg",
-            width = 800,
-            height = 600,
+        // Then
+        result.poses.size shouldBe 2
+        result.hasNext shouldBe false
+        result.poses[0].poseId shouldBe 1L
+        result.poses[0].scrap shouldBe true
+        result.poses[0].storageKey shouldBe "pose/image-101.jpg"
+        result.poses[1].poseId shouldBe 2L
+    }
+
+    @Test
+    @DisplayName("hasNext=true - 다음 페이지 존재")
+    fun `hasNext=true - 다음 페이지 존재`() {
+        // Given
+        val command = makeCommand(size = 2)
+        // size+1 = 3개 조회됨 → hasNext true
+        val poseList = listOf(
+            makePose(1L, 101L),
+            makePose(2L, 102L),
+            makePose(3L, 103L),
+        )
+        every {
+            poseRepository.listOwnedScrapPoses(
+                userId = 1L,
+                offset = 0,
+                limit = 3,
+                sortOrder = SortOrder.DESC,
+            )
+        } returns poseList
+
+        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
+            makeMediaStorageInfo(101L),
+            makeMediaStorageInfo(102L),
         )
 
-        test("정상 조회 + 미디어 매핑 - poses + storageInfo 반환") {
-            // Given
-            val command = makeCommand(size = 2)
-            val poseList = listOf(makePose(1L, 101L), makePose(2L, 102L))
+        // When
+        val result = useCase.execute(command)
 
-            every {
-                poseRepository.listOwnedScrapPoses(
-                    userId = 1L,
-                    offset = 0,
-                    limit = 3,
-                    sortOrder = SortOrder.DESC,
-                )
-            } returns poseList
+        // Then
+        result.hasNext shouldBe true
+        result.poses.size shouldBe 2
+    }
 
-            every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
-                makeMediaStorageInfo(101L),
-                makeMediaStorageInfo(102L),
+    @Test
+    @DisplayName("hasNext=false - 마지막 페이지")
+    fun `hasNext=false - 마지막 페이지`() {
+        // Given
+        val command = makeCommand(size = 5)
+        val poseList = listOf(makePose(1L, 101L), makePose(2L, 102L))
+
+        every {
+            poseRepository.listOwnedScrapPoses(
+                userId = 1L,
+                offset = 0,
+                limit = 6,
+                sortOrder = SortOrder.DESC,
             )
+        } returns poseList
 
-            // When
-            val result = useCase.execute(command)
+        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
+            makeMediaStorageInfo(101L),
+            makeMediaStorageInfo(102L),
+        )
 
-            // Then
-            result.poses.size shouldBe 2
-            result.hasNext shouldBe false
-            result.poses[0].poseId shouldBe 1L
-            result.poses[0].scrap shouldBe true
-            result.poses[0].storageKey shouldBe "pose/image-101.jpg"
-            result.poses[1].poseId shouldBe 2L
-        }
+        // When
+        val result = useCase.execute(command)
 
-        test("hasNext=true - 다음 페이지 존재") {
-            // Given
-            val command = makeCommand(size = 2)
-            // size+1 = 3개 조회됨 → hasNext true
-            val poseList = listOf(
-                makePose(1L, 101L),
-                makePose(2L, 102L),
-                makePose(3L, 103L),
+        // Then
+        result.hasNext shouldBe false
+        result.poses.size shouldBe 2
+    }
+
+    @Test
+    @DisplayName("빈 결과 - 빈 리스트와 hasNext=false 반환")
+    fun `빈 결과 - 빈 리스트와 hasNext=false 반환`() {
+        // Given
+        val command = makeCommand()
+        every {
+            poseRepository.listOwnedScrapPoses(
+                userId = 1L,
+                offset = 0,
+                limit = 11,
+                sortOrder = SortOrder.DESC,
             )
-            every {
-                poseRepository.listOwnedScrapPoses(
-                    userId = 1L,
-                    offset = 0,
-                    limit = 3,
-                    sortOrder = SortOrder.DESC,
-                )
-            } returns poseList
+        } returns emptyList()
 
-            every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
-                makeMediaStorageInfo(101L),
-                makeMediaStorageInfo(102L),
-            )
+        // When
+        val result = useCase.execute(command)
 
-            // When
-            val result = useCase.execute(command)
-
-            // Then
-            result.hasNext shouldBe true
-            result.poses.size shouldBe 2
-        }
-
-        test("hasNext=false - 마지막 페이지") {
-            // Given
-            val command = makeCommand(size = 5)
-            val poseList = listOf(makePose(1L, 101L), makePose(2L, 102L))
-
-            every {
-                poseRepository.listOwnedScrapPoses(
-                    userId = 1L,
-                    offset = 0,
-                    limit = 6,
-                    sortOrder = SortOrder.DESC,
-                )
-            } returns poseList
-
-            every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
-                makeMediaStorageInfo(101L),
-                makeMediaStorageInfo(102L),
-            )
-
-            // When
-            val result = useCase.execute(command)
-
-            // Then
-            result.hasNext shouldBe false
-            result.poses.size shouldBe 2
-        }
-
-        test("빈 결과 - 빈 리스트와 hasNext=false 반환") {
-            // Given
-            val command = makeCommand()
-            every {
-                poseRepository.listOwnedScrapPoses(
-                    userId = 1L,
-                    offset = 0,
-                    limit = 11,
-                    sortOrder = SortOrder.DESC,
-                )
-            } returns emptyList()
-
-            // When
-            val result = useCase.execute(command)
-
-            // Then
-            result.poses shouldBe emptyList()
-            result.hasNext shouldBe false
-        }
-    })
+        // Then
+        result.poses shouldBe emptyList()
+        result.hasNext shouldBe false
+    }
+}

--- a/src/test/kotlin/com/neki/pose/application/usecase/GetScrapPosesUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/GetScrapPosesUseCaseTest.kt
@@ -14,136 +14,149 @@ import io.mockk.every
 import io.mockk.mockk
 import java.time.LocalDateTime
 
-class GetScrapPosesUseCaseTest : FunSpec({
+class GetScrapPosesUseCaseTest :
+    FunSpec({
 
-    lateinit var poseRepository: PoseRepositoryPort
-    lateinit var mediaClient: MediaClientPort
-    lateinit var transactionRunner: FakeTransactionRunner
-    lateinit var useCase: GetScrapPosesUseCase
+        lateinit var poseRepository: PoseRepositoryPort
+        lateinit var mediaClient: MediaClientPort
+        lateinit var transactionRunner: FakeTransactionRunner
+        lateinit var useCase: GetScrapPosesUseCase
 
-    beforeTest {
-        poseRepository = mockk()
-        mediaClient = mockk()
-        transactionRunner = FakeTransactionRunner()
-        useCase = GetScrapPosesUseCase(poseRepository, mediaClient, transactionRunner)
-    }
+        beforeTest {
+            poseRepository = mockk()
+            mediaClient = mockk()
+            transactionRunner = FakeTransactionRunner()
+            useCase = GetScrapPosesUseCase(poseRepository, mediaClient, transactionRunner)
+        }
 
-    fun makeCommand(page: Int = 0, size: Int = 10): GetScrapPosesCommand = GetScrapPosesCommand(
-        userId = 1L,
-        page = page,
-        size = size,
-        headCount = null,
-        sortOrder = SortOrder.DESC,
-    )
-
-    fun makePose(id: Long, mediaId: Long): Pose {
-        val pose = aPose(id = id, mediaId = mediaId)
-        pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
-        return pose
-    }
-
-    fun makeMediaStorageInfo(mediaId: Long): MediaStorageInfo = MediaStorageInfo(
-        mediaId = mediaId,
-        storageKey = "pose/image-$mediaId.jpg",
-        contentType = "image/jpeg",
-        width = 800,
-        height = 600,
-    )
-
-    test("정상 조회 + 미디어 매핑 - poses + storageInfo 반환") {
-        // Given
-        val command = makeCommand(size = 2)
-        val poseList = listOf(makePose(1L, 101L), makePose(2L, 102L))
-
-        every {
-            poseRepository.listOwnedScrapPoses(
-                userId = 1L, offset = 0, limit = 3, sortOrder = SortOrder.DESC,
-            )
-        } returns poseList
-
-        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
-            makeMediaStorageInfo(101L),
-            makeMediaStorageInfo(102L),
+        fun makeCommand(page: Int = 0, size: Int = 10): GetScrapPosesCommand = GetScrapPosesCommand(
+            userId = 1L,
+            page = page,
+            size = size,
+            headCount = null,
+            sortOrder = SortOrder.DESC,
         )
 
-        // When
-        val result = useCase.execute(command)
+        fun makePose(id: Long, mediaId: Long): Pose {
+            val pose = aPose(id = id, mediaId = mediaId)
+            pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+            return pose
+        }
 
-        // Then
-        result.poses.size shouldBe 2
-        result.hasNext shouldBe false
-        result.poses[0].poseId shouldBe 1L
-        result.poses[0].scrap shouldBe true
-        result.poses[0].storageKey shouldBe "pose/image-101.jpg"
-        result.poses[1].poseId shouldBe 2L
-    }
-
-    test("hasNext=true - 다음 페이지 존재") {
-        // Given
-        val command = makeCommand(size = 2)
-        // size+1 = 3개 조회됨 → hasNext true
-        val poseList = listOf(
-            makePose(1L, 101L),
-            makePose(2L, 102L),
-            makePose(3L, 103L),
-        )
-        every {
-            poseRepository.listOwnedScrapPoses(
-                userId = 1L, offset = 0, limit = 3, sortOrder = SortOrder.DESC,
-            )
-        } returns poseList
-
-        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
-            makeMediaStorageInfo(101L),
-            makeMediaStorageInfo(102L),
+        fun makeMediaStorageInfo(mediaId: Long): MediaStorageInfo = MediaStorageInfo(
+            mediaId = mediaId,
+            storageKey = "pose/image-$mediaId.jpg",
+            contentType = "image/jpeg",
+            width = 800,
+            height = 600,
         )
 
-        // When
-        val result = useCase.execute(command)
+        test("정상 조회 + 미디어 매핑 - poses + storageInfo 반환") {
+            // Given
+            val command = makeCommand(size = 2)
+            val poseList = listOf(makePose(1L, 101L), makePose(2L, 102L))
 
-        // Then
-        result.hasNext shouldBe true
-        result.poses.size shouldBe 2
-    }
+            every {
+                poseRepository.listOwnedScrapPoses(
+                    userId = 1L,
+                    offset = 0,
+                    limit = 3,
+                    sortOrder = SortOrder.DESC,
+                )
+            } returns poseList
 
-    test("hasNext=false - 마지막 페이지") {
-        // Given
-        val command = makeCommand(size = 5)
-        val poseList = listOf(makePose(1L, 101L), makePose(2L, 102L))
-
-        every {
-            poseRepository.listOwnedScrapPoses(
-                userId = 1L, offset = 0, limit = 6, sortOrder = SortOrder.DESC,
+            every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
+                makeMediaStorageInfo(101L),
+                makeMediaStorageInfo(102L),
             )
-        } returns poseList
 
-        every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
-            makeMediaStorageInfo(101L),
-            makeMediaStorageInfo(102L),
-        )
+            // When
+            val result = useCase.execute(command)
 
-        // When
-        val result = useCase.execute(command)
+            // Then
+            result.poses.size shouldBe 2
+            result.hasNext shouldBe false
+            result.poses[0].poseId shouldBe 1L
+            result.poses[0].scrap shouldBe true
+            result.poses[0].storageKey shouldBe "pose/image-101.jpg"
+            result.poses[1].poseId shouldBe 2L
+        }
 
-        // Then
-        result.hasNext shouldBe false
-        result.poses.size shouldBe 2
-    }
-
-    test("빈 결과 - 빈 리스트와 hasNext=false 반환") {
-        // Given
-        val command = makeCommand()
-        every {
-            poseRepository.listOwnedScrapPoses(
-                userId = 1L, offset = 0, limit = 11, sortOrder = SortOrder.DESC,
+        test("hasNext=true - 다음 페이지 존재") {
+            // Given
+            val command = makeCommand(size = 2)
+            // size+1 = 3개 조회됨 → hasNext true
+            val poseList = listOf(
+                makePose(1L, 101L),
+                makePose(2L, 102L),
+                makePose(3L, 103L),
             )
-        } returns emptyList()
+            every {
+                poseRepository.listOwnedScrapPoses(
+                    userId = 1L,
+                    offset = 0,
+                    limit = 3,
+                    sortOrder = SortOrder.DESC,
+                )
+            } returns poseList
 
-        // When
-        val result = useCase.execute(command)
+            every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
+                makeMediaStorageInfo(101L),
+                makeMediaStorageInfo(102L),
+            )
 
-        // Then
-        result.poses shouldBe emptyList()
-        result.hasNext shouldBe false
-    }
-})
+            // When
+            val result = useCase.execute(command)
+
+            // Then
+            result.hasNext shouldBe true
+            result.poses.size shouldBe 2
+        }
+
+        test("hasNext=false - 마지막 페이지") {
+            // Given
+            val command = makeCommand(size = 5)
+            val poseList = listOf(makePose(1L, 101L), makePose(2L, 102L))
+
+            every {
+                poseRepository.listOwnedScrapPoses(
+                    userId = 1L,
+                    offset = 0,
+                    limit = 6,
+                    sortOrder = SortOrder.DESC,
+                )
+            } returns poseList
+
+            every { mediaClient.getMediaStorageInfos(listOf(101L, 102L)) } returns listOf(
+                makeMediaStorageInfo(101L),
+                makeMediaStorageInfo(102L),
+            )
+
+            // When
+            val result = useCase.execute(command)
+
+            // Then
+            result.hasNext shouldBe false
+            result.poses.size shouldBe 2
+        }
+
+        test("빈 결과 - 빈 리스트와 hasNext=false 반환") {
+            // Given
+            val command = makeCommand()
+            every {
+                poseRepository.listOwnedScrapPoses(
+                    userId = 1L,
+                    offset = 0,
+                    limit = 11,
+                    sortOrder = SortOrder.DESC,
+                )
+            } returns emptyList()
+
+            // When
+            val result = useCase.execute(command)
+
+            // Then
+            result.poses shouldBe emptyList()
+            result.hasNext shouldBe false
+        }
+    })

--- a/src/test/kotlin/com/neki/pose/application/usecase/RandomPoseUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/RandomPoseUseCaseTest.kt
@@ -11,126 +11,138 @@ import com.neki.pose.application.port.ScrapPoseRepositoryPort
 import com.neki.pose.domain.HeadCount
 import com.neki.testfixture.aPose
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
-class RandomPoseUseCaseTest :
-    FunSpec({
+class RandomPoseUseCaseTest {
 
-        lateinit var poseRepository: PoseRepositoryPort
-        lateinit var scrapPoseRepository: ScrapPoseRepositoryPort
-        lateinit var mediaClient: MediaClientPort
-        lateinit var randomGenerator: RandomGeneratorPort
-        lateinit var useCase: RandomPoseUseCase
+    private lateinit var poseRepository: PoseRepositoryPort
+    private lateinit var scrapPoseRepository: ScrapPoseRepositoryPort
+    private lateinit var mediaClient: MediaClientPort
+    private lateinit var randomGenerator: RandomGeneratorPort
+    private lateinit var useCase: RandomPoseUseCase
 
-        beforeTest {
-            poseRepository = mockk()
-            scrapPoseRepository = mockk()
-            mediaClient = mockk()
-            randomGenerator = mockk()
-            useCase = RandomPoseUseCase(poseRepository, scrapPoseRepository, mediaClient, randomGenerator)
+    @BeforeEach
+    fun setUp() {
+        poseRepository = mockk()
+        scrapPoseRepository = mockk()
+        mediaClient = mockk()
+        randomGenerator = mockk()
+        useCase = RandomPoseUseCase(poseRepository, scrapPoseRepository, mediaClient, randomGenerator)
+    }
+
+    private fun makeCommand(
+        userId: Long = 1L,
+        headCount: HeadCount = HeadCount.TWO,
+        excludeIds: List<Long> = emptyList(),
+    ): GetRandomPoseCommand = GetRandomPoseCommand(userId = userId, headCount = headCount, excludeIds = excludeIds)
+
+    private fun makeMediaStorageInfo(mediaId: Long): MediaStorageInfo = MediaStorageInfo(
+        mediaId = mediaId,
+        storageKey = "pose/image-$mediaId.jpg",
+        contentType = "image/jpeg",
+        width = 800,
+        height = 600,
+    )
+
+    @Test
+    @DisplayName("정상 - 랜덤 포즈 반환")
+    fun `정상 - 랜덤 포즈 반환`() {
+        // Given
+        val command = makeCommand()
+        val pose = aPose(id = 10L, mediaId = 101L, headCount = HeadCount.TWO)
+        pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+
+        every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 5L
+        every { randomGenerator.nextLong(5L) } returns 2L
+        every { poseRepository.findPoseByOffset(2L, HeadCount.TWO, emptyList()) } returns pose
+        every { scrapPoseRepository.existsOwnedPoseScrap(1L, 10L) } returns false
+        every { mediaClient.getMediaStorageInfo(101L) } returns makeMediaStorageInfo(101L)
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.poseId shouldBe 10L
+        result.storageKey shouldBe "pose/image-101.jpg"
+        result.scrap shouldBe false
+        result.headCount shouldBe HeadCount.TWO
+    }
+
+    @Test
+    @DisplayName("포즈 없음 → BusinessException(NO_MORE_RANDOM_POSE)")
+    fun `포즈 없음 → BusinessException(NO_MORE_RANDOM_POSE)`() {
+        // Given
+        val command = makeCommand()
+        every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 0L
+
+        // When / Then
+        val ex = shouldThrow<BusinessException> {
+            useCase.execute(command)
         }
+        ex.resultCode shouldBe ResultCode.NO_MORE_RANDOM_POSE
+    }
 
-        fun makeCommand(
-            userId: Long = 1L,
-            headCount: HeadCount = HeadCount.TWO,
-            excludeIds: List<Long> = emptyList(),
-        ): GetRandomPoseCommand = GetRandomPoseCommand(userId = userId, headCount = headCount, excludeIds = excludeIds)
+    @Test
+    @DisplayName("offset 포즈 미존재 (race condition) - findPoseByOffset null → BusinessException(NO_MORE_RANDOM_POSE)")
+    fun `offset 포즈 미존재 (race condition) - findPoseByOffset null → BusinessException(NO_MORE_RANDOM_POSE)`() {
+        // Given
+        val command = makeCommand()
+        every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 3L
+        every { randomGenerator.nextLong(3L) } returns 1L
+        every { poseRepository.findPoseByOffset(1L, HeadCount.TWO, emptyList()) } returns null
 
-        fun makeMediaStorageInfo(mediaId: Long): MediaStorageInfo = MediaStorageInfo(
-            mediaId = mediaId,
-            storageKey = "pose/image-$mediaId.jpg",
-            contentType = "image/jpeg",
-            width = 800,
-            height = 600,
-        )
-
-        test("정상 - 랜덤 포즈 반환") {
-            // Given
-            val command = makeCommand()
-            val pose = aPose(id = 10L, mediaId = 101L, headCount = HeadCount.TWO)
-            pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
-
-            every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 5L
-            every { randomGenerator.nextLong(5L) } returns 2L
-            every { poseRepository.findPoseByOffset(2L, HeadCount.TWO, emptyList()) } returns pose
-            every { scrapPoseRepository.existsOwnedPoseScrap(1L, 10L) } returns false
-            every { mediaClient.getMediaStorageInfo(101L) } returns makeMediaStorageInfo(101L)
-
-            // When
-            val result = useCase.execute(command)
-
-            // Then
-            result.poseId shouldBe 10L
-            result.storageKey shouldBe "pose/image-101.jpg"
-            result.scrap shouldBe false
-            result.headCount shouldBe HeadCount.TWO
+        // When / Then
+        val ex = shouldThrow<BusinessException> {
+            useCase.execute(command)
         }
+        ex.resultCode shouldBe ResultCode.NO_MORE_RANDOM_POSE
+    }
 
-        test("포즈 없음 → BusinessException(NO_MORE_RANDOM_POSE)") {
-            // Given
-            val command = makeCommand()
-            every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 0L
+    @Test
+    @DisplayName("count=1 - nextLong(1) → offset=0 → 하나의 포즈 반환")
+    fun `count=1 - nextLong(1) → offset=0 → 하나의 포즈 반환`() {
+        // Given
+        val command = makeCommand()
+        val pose = aPose(id = 5L, mediaId = 201L, headCount = HeadCount.TWO)
+        pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
 
-            // When / Then
-            val ex = shouldThrow<BusinessException> {
-                useCase.execute(command)
-            }
-            ex.resultCode shouldBe ResultCode.NO_MORE_RANDOM_POSE
+        every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 1L
+        every { randomGenerator.nextLong(1L) } returns 0L
+        every { poseRepository.findPoseByOffset(0L, HeadCount.TWO, emptyList()) } returns pose
+        every { scrapPoseRepository.existsOwnedPoseScrap(1L, 5L) } returns true
+        every { mediaClient.getMediaStorageInfo(201L) } returns makeMediaStorageInfo(201L)
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.poseId shouldBe 5L
+        result.scrap shouldBe true
+    }
+
+    @Test
+    @DisplayName("mediaClient 예외 - 포즈 선택 후 미디어 조회 실패")
+    fun `mediaClient 예외 - 포즈 선택 후 미디어 조회 실패`() {
+        // Given
+        val command = makeCommand()
+        val pose = aPose(id = 10L, mediaId = 101L, headCount = HeadCount.TWO)
+        pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+
+        every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 5L
+        every { randomGenerator.nextLong(5L) } returns 2L
+        every { poseRepository.findPoseByOffset(2L, HeadCount.TWO, emptyList()) } returns pose
+        every { scrapPoseRepository.existsOwnedPoseScrap(1L, 10L) } returns false
+        every { mediaClient.getMediaStorageInfo(101L) } throws RuntimeException("미디어 조회 실패")
+
+        // When / Then
+        shouldThrow<RuntimeException> {
+            useCase.execute(command)
         }
-
-        test("offset 포즈 미존재 (race condition) - findPoseByOffset null → BusinessException(NO_MORE_RANDOM_POSE)") {
-            // Given
-            val command = makeCommand()
-            every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 3L
-            every { randomGenerator.nextLong(3L) } returns 1L
-            every { poseRepository.findPoseByOffset(1L, HeadCount.TWO, emptyList()) } returns null
-
-            // When / Then
-            val ex = shouldThrow<BusinessException> {
-                useCase.execute(command)
-            }
-            ex.resultCode shouldBe ResultCode.NO_MORE_RANDOM_POSE
-        }
-
-        test("count=1 - nextLong(1) → offset=0 → 하나의 포즈 반환") {
-            // Given
-            val command = makeCommand()
-            val pose = aPose(id = 5L, mediaId = 201L, headCount = HeadCount.TWO)
-            pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
-
-            every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 1L
-            every { randomGenerator.nextLong(1L) } returns 0L
-            every { poseRepository.findPoseByOffset(0L, HeadCount.TWO, emptyList()) } returns pose
-            every { scrapPoseRepository.existsOwnedPoseScrap(1L, 5L) } returns true
-            every { mediaClient.getMediaStorageInfo(201L) } returns makeMediaStorageInfo(201L)
-
-            // When
-            val result = useCase.execute(command)
-
-            // Then
-            result.poseId shouldBe 5L
-            result.scrap shouldBe true
-        }
-
-        test("mediaClient 예외 - 포즈 선택 후 미디어 조회 실패") {
-            // Given
-            val command = makeCommand()
-            val pose = aPose(id = 10L, mediaId = 101L, headCount = HeadCount.TWO)
-            pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
-
-            every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 5L
-            every { randomGenerator.nextLong(5L) } returns 2L
-            every { poseRepository.findPoseByOffset(2L, HeadCount.TWO, emptyList()) } returns pose
-            every { scrapPoseRepository.existsOwnedPoseScrap(1L, 10L) } returns false
-            every { mediaClient.getMediaStorageInfo(101L) } throws RuntimeException("미디어 조회 실패")
-
-            // When / Then
-            shouldThrow<RuntimeException> {
-                useCase.execute(command)
-            }
-        }
-    })
+    }
+}

--- a/src/test/kotlin/com/neki/pose/application/usecase/RandomPoseUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/RandomPoseUseCaseTest.kt
@@ -1,0 +1,135 @@
+package com.neki.pose.application.usecase
+
+import com.neki.common.api.dto.ResultCode
+import com.neki.common.exception.BusinessException
+import com.neki.pose.application.command.GetRandomPoseCommand
+import com.neki.pose.application.contract.MediaStorageInfo
+import com.neki.pose.application.port.MediaClientPort
+import com.neki.pose.application.port.PoseRepositoryPort
+import com.neki.pose.application.port.RandomGeneratorPort
+import com.neki.pose.application.port.ScrapPoseRepositoryPort
+import com.neki.pose.domain.HeadCount
+import com.neki.testfixture.aPose
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDateTime
+
+class RandomPoseUseCaseTest : FunSpec({
+
+    lateinit var poseRepository: PoseRepositoryPort
+    lateinit var scrapPoseRepository: ScrapPoseRepositoryPort
+    lateinit var mediaClient: MediaClientPort
+    lateinit var randomGenerator: RandomGeneratorPort
+    lateinit var useCase: RandomPoseUseCase
+
+    beforeTest {
+        poseRepository = mockk()
+        scrapPoseRepository = mockk()
+        mediaClient = mockk()
+        randomGenerator = mockk()
+        useCase = RandomPoseUseCase(poseRepository, scrapPoseRepository, mediaClient, randomGenerator)
+    }
+
+    fun makeCommand(
+        userId: Long = 1L,
+        headCount: HeadCount = HeadCount.TWO,
+        excludeIds: List<Long> = emptyList(),
+    ): GetRandomPoseCommand = GetRandomPoseCommand(userId = userId, headCount = headCount, excludeIds = excludeIds)
+
+    fun makeMediaStorageInfo(mediaId: Long): MediaStorageInfo = MediaStorageInfo(
+        mediaId = mediaId,
+        storageKey = "pose/image-$mediaId.jpg",
+        contentType = "image/jpeg",
+        width = 800,
+        height = 600,
+    )
+
+    test("정상 - 랜덤 포즈 반환") {
+        // Given
+        val command = makeCommand()
+        val pose = aPose(id = 10L, mediaId = 101L, headCount = HeadCount.TWO)
+        pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+
+        every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 5L
+        every { randomGenerator.nextLong(5L) } returns 2L
+        every { poseRepository.findPoseByOffset(2L, HeadCount.TWO, emptyList()) } returns pose
+        every { scrapPoseRepository.existsOwnedPoseScrap(1L, 10L) } returns false
+        every { mediaClient.getMediaStorageInfo(101L) } returns makeMediaStorageInfo(101L)
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.poseId shouldBe 10L
+        result.storageKey shouldBe "pose/image-101.jpg"
+        result.scrap shouldBe false
+        result.headCount shouldBe HeadCount.TWO
+    }
+
+    test("포즈 없음 → BusinessException(NO_MORE_RANDOM_POSE)") {
+        // Given
+        val command = makeCommand()
+        every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 0L
+
+        // When / Then
+        val ex = shouldThrow<BusinessException> {
+            useCase.execute(command)
+        }
+        ex.resultCode shouldBe ResultCode.NO_MORE_RANDOM_POSE
+    }
+
+    test("offset 포즈 미존재 (race condition) - findPoseByOffset null → BusinessException(NO_MORE_RANDOM_POSE)") {
+        // Given
+        val command = makeCommand()
+        every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 3L
+        every { randomGenerator.nextLong(3L) } returns 1L
+        every { poseRepository.findPoseByOffset(1L, HeadCount.TWO, emptyList()) } returns null
+
+        // When / Then
+        val ex = shouldThrow<BusinessException> {
+            useCase.execute(command)
+        }
+        ex.resultCode shouldBe ResultCode.NO_MORE_RANDOM_POSE
+    }
+
+    test("count=1 - nextLong(1) → offset=0 → 하나의 포즈 반환") {
+        // Given
+        val command = makeCommand()
+        val pose = aPose(id = 5L, mediaId = 201L, headCount = HeadCount.TWO)
+        pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+
+        every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 1L
+        every { randomGenerator.nextLong(1L) } returns 0L
+        every { poseRepository.findPoseByOffset(0L, HeadCount.TWO, emptyList()) } returns pose
+        every { scrapPoseRepository.existsOwnedPoseScrap(1L, 5L) } returns true
+        every { mediaClient.getMediaStorageInfo(201L) } returns makeMediaStorageInfo(201L)
+
+        // When
+        val result = useCase.execute(command)
+
+        // Then
+        result.poseId shouldBe 5L
+        result.scrap shouldBe true
+    }
+
+    test("mediaClient 예외 - 포즈 선택 후 미디어 조회 실패") {
+        // Given
+        val command = makeCommand()
+        val pose = aPose(id = 10L, mediaId = 101L, headCount = HeadCount.TWO)
+        pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+
+        every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 5L
+        every { randomGenerator.nextLong(5L) } returns 2L
+        every { poseRepository.findPoseByOffset(2L, HeadCount.TWO, emptyList()) } returns pose
+        every { scrapPoseRepository.existsOwnedPoseScrap(1L, 10L) } returns false
+        every { mediaClient.getMediaStorageInfo(101L) } throws RuntimeException("미디어 조회 실패")
+
+        // When / Then
+        shouldThrow<RuntimeException> {
+            useCase.execute(command)
+        }
+    }
+})

--- a/src/test/kotlin/com/neki/pose/application/usecase/RandomPoseUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/RandomPoseUseCaseTest.kt
@@ -17,119 +17,120 @@ import io.mockk.every
 import io.mockk.mockk
 import java.time.LocalDateTime
 
-class RandomPoseUseCaseTest : FunSpec({
+class RandomPoseUseCaseTest :
+    FunSpec({
 
-    lateinit var poseRepository: PoseRepositoryPort
-    lateinit var scrapPoseRepository: ScrapPoseRepositoryPort
-    lateinit var mediaClient: MediaClientPort
-    lateinit var randomGenerator: RandomGeneratorPort
-    lateinit var useCase: RandomPoseUseCase
+        lateinit var poseRepository: PoseRepositoryPort
+        lateinit var scrapPoseRepository: ScrapPoseRepositoryPort
+        lateinit var mediaClient: MediaClientPort
+        lateinit var randomGenerator: RandomGeneratorPort
+        lateinit var useCase: RandomPoseUseCase
 
-    beforeTest {
-        poseRepository = mockk()
-        scrapPoseRepository = mockk()
-        mediaClient = mockk()
-        randomGenerator = mockk()
-        useCase = RandomPoseUseCase(poseRepository, scrapPoseRepository, mediaClient, randomGenerator)
-    }
-
-    fun makeCommand(
-        userId: Long = 1L,
-        headCount: HeadCount = HeadCount.TWO,
-        excludeIds: List<Long> = emptyList(),
-    ): GetRandomPoseCommand = GetRandomPoseCommand(userId = userId, headCount = headCount, excludeIds = excludeIds)
-
-    fun makeMediaStorageInfo(mediaId: Long): MediaStorageInfo = MediaStorageInfo(
-        mediaId = mediaId,
-        storageKey = "pose/image-$mediaId.jpg",
-        contentType = "image/jpeg",
-        width = 800,
-        height = 600,
-    )
-
-    test("정상 - 랜덤 포즈 반환") {
-        // Given
-        val command = makeCommand()
-        val pose = aPose(id = 10L, mediaId = 101L, headCount = HeadCount.TWO)
-        pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
-
-        every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 5L
-        every { randomGenerator.nextLong(5L) } returns 2L
-        every { poseRepository.findPoseByOffset(2L, HeadCount.TWO, emptyList()) } returns pose
-        every { scrapPoseRepository.existsOwnedPoseScrap(1L, 10L) } returns false
-        every { mediaClient.getMediaStorageInfo(101L) } returns makeMediaStorageInfo(101L)
-
-        // When
-        val result = useCase.execute(command)
-
-        // Then
-        result.poseId shouldBe 10L
-        result.storageKey shouldBe "pose/image-101.jpg"
-        result.scrap shouldBe false
-        result.headCount shouldBe HeadCount.TWO
-    }
-
-    test("포즈 없음 → BusinessException(NO_MORE_RANDOM_POSE)") {
-        // Given
-        val command = makeCommand()
-        every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 0L
-
-        // When / Then
-        val ex = shouldThrow<BusinessException> {
-            useCase.execute(command)
+        beforeTest {
+            poseRepository = mockk()
+            scrapPoseRepository = mockk()
+            mediaClient = mockk()
+            randomGenerator = mockk()
+            useCase = RandomPoseUseCase(poseRepository, scrapPoseRepository, mediaClient, randomGenerator)
         }
-        ex.resultCode shouldBe ResultCode.NO_MORE_RANDOM_POSE
-    }
 
-    test("offset 포즈 미존재 (race condition) - findPoseByOffset null → BusinessException(NO_MORE_RANDOM_POSE)") {
-        // Given
-        val command = makeCommand()
-        every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 3L
-        every { randomGenerator.nextLong(3L) } returns 1L
-        every { poseRepository.findPoseByOffset(1L, HeadCount.TWO, emptyList()) } returns null
+        fun makeCommand(
+            userId: Long = 1L,
+            headCount: HeadCount = HeadCount.TWO,
+            excludeIds: List<Long> = emptyList(),
+        ): GetRandomPoseCommand = GetRandomPoseCommand(userId = userId, headCount = headCount, excludeIds = excludeIds)
 
-        // When / Then
-        val ex = shouldThrow<BusinessException> {
-            useCase.execute(command)
+        fun makeMediaStorageInfo(mediaId: Long): MediaStorageInfo = MediaStorageInfo(
+            mediaId = mediaId,
+            storageKey = "pose/image-$mediaId.jpg",
+            contentType = "image/jpeg",
+            width = 800,
+            height = 600,
+        )
+
+        test("정상 - 랜덤 포즈 반환") {
+            // Given
+            val command = makeCommand()
+            val pose = aPose(id = 10L, mediaId = 101L, headCount = HeadCount.TWO)
+            pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+
+            every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 5L
+            every { randomGenerator.nextLong(5L) } returns 2L
+            every { poseRepository.findPoseByOffset(2L, HeadCount.TWO, emptyList()) } returns pose
+            every { scrapPoseRepository.existsOwnedPoseScrap(1L, 10L) } returns false
+            every { mediaClient.getMediaStorageInfo(101L) } returns makeMediaStorageInfo(101L)
+
+            // When
+            val result = useCase.execute(command)
+
+            // Then
+            result.poseId shouldBe 10L
+            result.storageKey shouldBe "pose/image-101.jpg"
+            result.scrap shouldBe false
+            result.headCount shouldBe HeadCount.TWO
         }
-        ex.resultCode shouldBe ResultCode.NO_MORE_RANDOM_POSE
-    }
 
-    test("count=1 - nextLong(1) → offset=0 → 하나의 포즈 반환") {
-        // Given
-        val command = makeCommand()
-        val pose = aPose(id = 5L, mediaId = 201L, headCount = HeadCount.TWO)
-        pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+        test("포즈 없음 → BusinessException(NO_MORE_RANDOM_POSE)") {
+            // Given
+            val command = makeCommand()
+            every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 0L
 
-        every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 1L
-        every { randomGenerator.nextLong(1L) } returns 0L
-        every { poseRepository.findPoseByOffset(0L, HeadCount.TWO, emptyList()) } returns pose
-        every { scrapPoseRepository.existsOwnedPoseScrap(1L, 5L) } returns true
-        every { mediaClient.getMediaStorageInfo(201L) } returns makeMediaStorageInfo(201L)
-
-        // When
-        val result = useCase.execute(command)
-
-        // Then
-        result.poseId shouldBe 5L
-        result.scrap shouldBe true
-    }
-
-    test("mediaClient 예외 - 포즈 선택 후 미디어 조회 실패") {
-        // Given
-        val command = makeCommand()
-        val pose = aPose(id = 10L, mediaId = 101L, headCount = HeadCount.TWO)
-        pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
-
-        every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 5L
-        every { randomGenerator.nextLong(5L) } returns 2L
-        every { poseRepository.findPoseByOffset(2L, HeadCount.TWO, emptyList()) } returns pose
-        every { scrapPoseRepository.existsOwnedPoseScrap(1L, 10L) } returns false
-        every { mediaClient.getMediaStorageInfo(101L) } throws RuntimeException("미디어 조회 실패")
-
-        // When / Then
-        shouldThrow<RuntimeException> {
-            useCase.execute(command)
+            // When / Then
+            val ex = shouldThrow<BusinessException> {
+                useCase.execute(command)
+            }
+            ex.resultCode shouldBe ResultCode.NO_MORE_RANDOM_POSE
         }
-    }
-})
+
+        test("offset 포즈 미존재 (race condition) - findPoseByOffset null → BusinessException(NO_MORE_RANDOM_POSE)") {
+            // Given
+            val command = makeCommand()
+            every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 3L
+            every { randomGenerator.nextLong(3L) } returns 1L
+            every { poseRepository.findPoseByOffset(1L, HeadCount.TWO, emptyList()) } returns null
+
+            // When / Then
+            val ex = shouldThrow<BusinessException> {
+                useCase.execute(command)
+            }
+            ex.resultCode shouldBe ResultCode.NO_MORE_RANDOM_POSE
+        }
+
+        test("count=1 - nextLong(1) → offset=0 → 하나의 포즈 반환") {
+            // Given
+            val command = makeCommand()
+            val pose = aPose(id = 5L, mediaId = 201L, headCount = HeadCount.TWO)
+            pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+
+            every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 1L
+            every { randomGenerator.nextLong(1L) } returns 0L
+            every { poseRepository.findPoseByOffset(0L, HeadCount.TWO, emptyList()) } returns pose
+            every { scrapPoseRepository.existsOwnedPoseScrap(1L, 5L) } returns true
+            every { mediaClient.getMediaStorageInfo(201L) } returns makeMediaStorageInfo(201L)
+
+            // When
+            val result = useCase.execute(command)
+
+            // Then
+            result.poseId shouldBe 5L
+            result.scrap shouldBe true
+        }
+
+        test("mediaClient 예외 - 포즈 선택 후 미디어 조회 실패") {
+            // Given
+            val command = makeCommand()
+            val pose = aPose(id = 10L, mediaId = 101L, headCount = HeadCount.TWO)
+            pose.createdAt = LocalDateTime.of(2026, 1, 1, 0, 0)
+
+            every { poseRepository.countPoses(HeadCount.TWO, emptyList()) } returns 5L
+            every { randomGenerator.nextLong(5L) } returns 2L
+            every { poseRepository.findPoseByOffset(2L, HeadCount.TWO, emptyList()) } returns pose
+            every { scrapPoseRepository.existsOwnedPoseScrap(1L, 10L) } returns false
+            every { mediaClient.getMediaStorageInfo(101L) } throws RuntimeException("미디어 조회 실패")
+
+            // When / Then
+            shouldThrow<RuntimeException> {
+                useCase.execute(command)
+            }
+        }
+    })

--- a/src/test/kotlin/com/neki/pose/application/usecase/UpdatePoseScrapUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/UpdatePoseScrapUseCaseTest.kt
@@ -1,0 +1,96 @@
+package com.neki.pose.application.usecase
+
+import com.neki.common.api.dto.ResultCode
+import com.neki.common.exception.BusinessException
+import com.neki.pose.application.command.UpdatePoseScrapCommand
+import com.neki.pose.application.port.PoseRepositoryPort
+import com.neki.pose.application.port.ScrapPoseRepositoryPort
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+
+class UpdatePoseScrapUseCaseTest : FunSpec({
+
+    lateinit var poseRepository: PoseRepositoryPort
+    lateinit var scrapPoseRepository: ScrapPoseRepositoryPort
+    lateinit var useCase: UpdatePoseScrapUseCase
+
+    beforeTest {
+        poseRepository = mockk()
+        scrapPoseRepository = mockk()
+        useCase = UpdatePoseScrapUseCase(poseRepository, scrapPoseRepository)
+    }
+
+    test("스크랩 추가 (scrap=true) - add() 호출 확인") {
+        // Given
+        val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = true)
+        every { poseRepository.existsPose(10L) } returns true
+        every { scrapPoseRepository.add(1L, 10L) } just Runs
+
+        // When
+        useCase.execute(command)
+
+        // Then
+        verify(exactly = 1) { scrapPoseRepository.add(1L, 10L) }
+        verify(exactly = 0) { scrapPoseRepository.delete(any(), any()) }
+    }
+
+    test("스크랩 해제 (scrap=false) - delete() 호출 확인") {
+        // Given
+        val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = false)
+        every { poseRepository.existsPose(10L) } returns true
+        every { scrapPoseRepository.delete(1L, 10L) } just Runs
+
+        // When
+        useCase.execute(command)
+
+        // Then
+        verify(exactly = 1) { scrapPoseRepository.delete(1L, 10L) }
+        verify(exactly = 0) { scrapPoseRepository.add(any(), any()) }
+    }
+
+    test("포즈 미존재 → BusinessException(NOT_FOUND)") {
+        // Given
+        val command = UpdatePoseScrapCommand(userId = 1L, poseId = 999L, scrap = true)
+        every { poseRepository.existsPose(999L) } returns false
+
+        // When / Then
+        val ex = shouldThrow<BusinessException> {
+            useCase.execute(command)
+        }
+        ex.resultCode shouldBe ResultCode.NOT_FOUND
+        verify(exactly = 0) { scrapPoseRepository.add(any(), any()) }
+        verify(exactly = 0) { scrapPoseRepository.delete(any(), any()) }
+    }
+
+    test("이미 스크랩된 포즈에 add - 멱등성 (예외 없이 add 호출)") {
+        // Given
+        val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = true)
+        every { poseRepository.existsPose(10L) } returns true
+        every { scrapPoseRepository.add(1L, 10L) } just Runs
+
+        // When
+        useCase.execute(command)
+
+        // Then - 예외 없이 정상 처리
+        verify(exactly = 1) { scrapPoseRepository.add(1L, 10L) }
+    }
+
+    test("스크랩 안 된 포즈에 delete - 멱등성 (예외 없이 delete 호출)") {
+        // Given
+        val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = false)
+        every { poseRepository.existsPose(10L) } returns true
+        every { scrapPoseRepository.delete(1L, 10L) } just Runs
+
+        // When
+        useCase.execute(command)
+
+        // Then - 예외 없이 정상 처리
+        verify(exactly = 1) { scrapPoseRepository.delete(1L, 10L) }
+    }
+})

--- a/src/test/kotlin/com/neki/pose/application/usecase/UpdatePoseScrapUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/UpdatePoseScrapUseCaseTest.kt
@@ -14,83 +14,84 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 
-class UpdatePoseScrapUseCaseTest : FunSpec({
+class UpdatePoseScrapUseCaseTest :
+    FunSpec({
 
-    lateinit var poseRepository: PoseRepositoryPort
-    lateinit var scrapPoseRepository: ScrapPoseRepositoryPort
-    lateinit var useCase: UpdatePoseScrapUseCase
+        lateinit var poseRepository: PoseRepositoryPort
+        lateinit var scrapPoseRepository: ScrapPoseRepositoryPort
+        lateinit var useCase: UpdatePoseScrapUseCase
 
-    beforeTest {
-        poseRepository = mockk()
-        scrapPoseRepository = mockk()
-        useCase = UpdatePoseScrapUseCase(poseRepository, scrapPoseRepository)
-    }
-
-    test("스크랩 추가 (scrap=true) - add() 호출 확인") {
-        // Given
-        val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = true)
-        every { poseRepository.existsPose(10L) } returns true
-        every { scrapPoseRepository.add(1L, 10L) } just Runs
-
-        // When
-        useCase.execute(command)
-
-        // Then
-        verify(exactly = 1) { scrapPoseRepository.add(1L, 10L) }
-        verify(exactly = 0) { scrapPoseRepository.delete(any(), any()) }
-    }
-
-    test("스크랩 해제 (scrap=false) - delete() 호출 확인") {
-        // Given
-        val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = false)
-        every { poseRepository.existsPose(10L) } returns true
-        every { scrapPoseRepository.delete(1L, 10L) } just Runs
-
-        // When
-        useCase.execute(command)
-
-        // Then
-        verify(exactly = 1) { scrapPoseRepository.delete(1L, 10L) }
-        verify(exactly = 0) { scrapPoseRepository.add(any(), any()) }
-    }
-
-    test("포즈 미존재 → BusinessException(NOT_FOUND)") {
-        // Given
-        val command = UpdatePoseScrapCommand(userId = 1L, poseId = 999L, scrap = true)
-        every { poseRepository.existsPose(999L) } returns false
-
-        // When / Then
-        val ex = shouldThrow<BusinessException> {
-            useCase.execute(command)
+        beforeTest {
+            poseRepository = mockk()
+            scrapPoseRepository = mockk()
+            useCase = UpdatePoseScrapUseCase(poseRepository, scrapPoseRepository)
         }
-        ex.resultCode shouldBe ResultCode.NOT_FOUND
-        verify(exactly = 0) { scrapPoseRepository.add(any(), any()) }
-        verify(exactly = 0) { scrapPoseRepository.delete(any(), any()) }
-    }
 
-    test("이미 스크랩된 포즈에 add - 멱등성 (예외 없이 add 호출)") {
-        // Given
-        val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = true)
-        every { poseRepository.existsPose(10L) } returns true
-        every { scrapPoseRepository.add(1L, 10L) } just Runs
+        test("스크랩 추가 (scrap=true) - add() 호출 확인") {
+            // Given
+            val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = true)
+            every { poseRepository.existsPose(10L) } returns true
+            every { scrapPoseRepository.add(1L, 10L) } just Runs
 
-        // When
-        useCase.execute(command)
+            // When
+            useCase.execute(command)
 
-        // Then - 예외 없이 정상 처리
-        verify(exactly = 1) { scrapPoseRepository.add(1L, 10L) }
-    }
+            // Then
+            verify(exactly = 1) { scrapPoseRepository.add(1L, 10L) }
+            verify(exactly = 0) { scrapPoseRepository.delete(any(), any()) }
+        }
 
-    test("스크랩 안 된 포즈에 delete - 멱등성 (예외 없이 delete 호출)") {
-        // Given
-        val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = false)
-        every { poseRepository.existsPose(10L) } returns true
-        every { scrapPoseRepository.delete(1L, 10L) } just Runs
+        test("스크랩 해제 (scrap=false) - delete() 호출 확인") {
+            // Given
+            val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = false)
+            every { poseRepository.existsPose(10L) } returns true
+            every { scrapPoseRepository.delete(1L, 10L) } just Runs
 
-        // When
-        useCase.execute(command)
+            // When
+            useCase.execute(command)
 
-        // Then - 예외 없이 정상 처리
-        verify(exactly = 1) { scrapPoseRepository.delete(1L, 10L) }
-    }
-})
+            // Then
+            verify(exactly = 1) { scrapPoseRepository.delete(1L, 10L) }
+            verify(exactly = 0) { scrapPoseRepository.add(any(), any()) }
+        }
+
+        test("포즈 미존재 → BusinessException(NOT_FOUND)") {
+            // Given
+            val command = UpdatePoseScrapCommand(userId = 1L, poseId = 999L, scrap = true)
+            every { poseRepository.existsPose(999L) } returns false
+
+            // When / Then
+            val ex = shouldThrow<BusinessException> {
+                useCase.execute(command)
+            }
+            ex.resultCode shouldBe ResultCode.NOT_FOUND
+            verify(exactly = 0) { scrapPoseRepository.add(any(), any()) }
+            verify(exactly = 0) { scrapPoseRepository.delete(any(), any()) }
+        }
+
+        test("이미 스크랩된 포즈에 add - 멱등성 (예외 없이 add 호출)") {
+            // Given
+            val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = true)
+            every { poseRepository.existsPose(10L) } returns true
+            every { scrapPoseRepository.add(1L, 10L) } just Runs
+
+            // When
+            useCase.execute(command)
+
+            // Then - 예외 없이 정상 처리
+            verify(exactly = 1) { scrapPoseRepository.add(1L, 10L) }
+        }
+
+        test("스크랩 안 된 포즈에 delete - 멱등성 (예외 없이 delete 호출)") {
+            // Given
+            val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = false)
+            every { poseRepository.existsPose(10L) } returns true
+            every { scrapPoseRepository.delete(1L, 10L) } just Runs
+
+            // When
+            useCase.execute(command)
+
+            // Then - 예외 없이 정상 처리
+            verify(exactly = 1) { scrapPoseRepository.delete(1L, 10L) }
+        }
+    })

--- a/src/test/kotlin/com/neki/pose/application/usecase/UpdatePoseScrapUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/UpdatePoseScrapUseCaseTest.kt
@@ -6,92 +6,104 @@ import com.neki.pose.application.command.UpdatePoseScrapCommand
 import com.neki.pose.application.port.PoseRepositoryPort
 import com.neki.pose.application.port.ScrapPoseRepositoryPort
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-class UpdatePoseScrapUseCaseTest :
-    FunSpec({
+class UpdatePoseScrapUseCaseTest {
 
-        lateinit var poseRepository: PoseRepositoryPort
-        lateinit var scrapPoseRepository: ScrapPoseRepositoryPort
-        lateinit var useCase: UpdatePoseScrapUseCase
+    private lateinit var poseRepository: PoseRepositoryPort
+    private lateinit var scrapPoseRepository: ScrapPoseRepositoryPort
+    private lateinit var useCase: UpdatePoseScrapUseCase
 
-        beforeTest {
-            poseRepository = mockk()
-            scrapPoseRepository = mockk()
-            useCase = UpdatePoseScrapUseCase(poseRepository, scrapPoseRepository)
-        }
+    @BeforeEach
+    fun setUp() {
+        poseRepository = mockk()
+        scrapPoseRepository = mockk()
+        useCase = UpdatePoseScrapUseCase(poseRepository, scrapPoseRepository)
+    }
 
-        test("스크랩 추가 (scrap=true) - add() 호출 확인") {
-            // Given
-            val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = true)
-            every { poseRepository.existsPose(10L) } returns true
-            every { scrapPoseRepository.add(1L, 10L) } just Runs
+    @Test
+    @DisplayName("스크랩 추가 (scrap=true) - add() 호출 확인")
+    fun `스크랩 추가 (scrap=true) - add() 호출 확인`() {
+        // Given
+        val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = true)
+        every { poseRepository.existsPose(10L) } returns true
+        every { scrapPoseRepository.add(1L, 10L) } just Runs
 
-            // When
+        // When
+        useCase.execute(command)
+
+        // Then
+        verify(exactly = 1) { scrapPoseRepository.add(1L, 10L) }
+        verify(exactly = 0) { scrapPoseRepository.delete(any(), any()) }
+    }
+
+    @Test
+    @DisplayName("스크랩 해제 (scrap=false) - delete() 호출 확인")
+    fun `스크랩 해제 (scrap=false) - delete() 호출 확인`() {
+        // Given
+        val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = false)
+        every { poseRepository.existsPose(10L) } returns true
+        every { scrapPoseRepository.delete(1L, 10L) } just Runs
+
+        // When
+        useCase.execute(command)
+
+        // Then
+        verify(exactly = 1) { scrapPoseRepository.delete(1L, 10L) }
+        verify(exactly = 0) { scrapPoseRepository.add(any(), any()) }
+    }
+
+    @Test
+    @DisplayName("포즈 미존재 → BusinessException(NOT_FOUND)")
+    fun `포즈 미존재 → BusinessException(NOT_FOUND)`() {
+        // Given
+        val command = UpdatePoseScrapCommand(userId = 1L, poseId = 999L, scrap = true)
+        every { poseRepository.existsPose(999L) } returns false
+
+        // When / Then
+        val ex = shouldThrow<BusinessException> {
             useCase.execute(command)
-
-            // Then
-            verify(exactly = 1) { scrapPoseRepository.add(1L, 10L) }
-            verify(exactly = 0) { scrapPoseRepository.delete(any(), any()) }
         }
+        ex.resultCode shouldBe ResultCode.NOT_FOUND
+        verify(exactly = 0) { scrapPoseRepository.add(any(), any()) }
+        verify(exactly = 0) { scrapPoseRepository.delete(any(), any()) }
+    }
 
-        test("스크랩 해제 (scrap=false) - delete() 호출 확인") {
-            // Given
-            val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = false)
-            every { poseRepository.existsPose(10L) } returns true
-            every { scrapPoseRepository.delete(1L, 10L) } just Runs
+    @Test
+    @DisplayName("이미 스크랩된 포즈에 add - 멱등성 (예외 없이 add 호출)")
+    fun `이미 스크랩된 포즈에 add - 멱등성 (예외 없이 add 호출)`() {
+        // Given
+        val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = true)
+        every { poseRepository.existsPose(10L) } returns true
+        every { scrapPoseRepository.add(1L, 10L) } just Runs
 
-            // When
-            useCase.execute(command)
+        // When
+        useCase.execute(command)
 
-            // Then
-            verify(exactly = 1) { scrapPoseRepository.delete(1L, 10L) }
-            verify(exactly = 0) { scrapPoseRepository.add(any(), any()) }
-        }
+        // Then - 예외 없이 정상 처리
+        verify(exactly = 1) { scrapPoseRepository.add(1L, 10L) }
+    }
 
-        test("포즈 미존재 → BusinessException(NOT_FOUND)") {
-            // Given
-            val command = UpdatePoseScrapCommand(userId = 1L, poseId = 999L, scrap = true)
-            every { poseRepository.existsPose(999L) } returns false
+    @Test
+    @DisplayName("스크랩 안 된 포즈에 delete - 멱등성 (예외 없이 delete 호출)")
+    fun `스크랩 안 된 포즈에 delete - 멱등성 (예외 없이 delete 호출)`() {
+        // Given
+        val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = false)
+        every { poseRepository.existsPose(10L) } returns true
+        every { scrapPoseRepository.delete(1L, 10L) } just Runs
 
-            // When / Then
-            val ex = shouldThrow<BusinessException> {
-                useCase.execute(command)
-            }
-            ex.resultCode shouldBe ResultCode.NOT_FOUND
-            verify(exactly = 0) { scrapPoseRepository.add(any(), any()) }
-            verify(exactly = 0) { scrapPoseRepository.delete(any(), any()) }
-        }
+        // When
+        useCase.execute(command)
 
-        test("이미 스크랩된 포즈에 add - 멱등성 (예외 없이 add 호출)") {
-            // Given
-            val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = true)
-            every { poseRepository.existsPose(10L) } returns true
-            every { scrapPoseRepository.add(1L, 10L) } just Runs
-
-            // When
-            useCase.execute(command)
-
-            // Then - 예외 없이 정상 처리
-            verify(exactly = 1) { scrapPoseRepository.add(1L, 10L) }
-        }
-
-        test("스크랩 안 된 포즈에 delete - 멱등성 (예외 없이 delete 호출)") {
-            // Given
-            val command = UpdatePoseScrapCommand(userId = 1L, poseId = 10L, scrap = false)
-            every { poseRepository.existsPose(10L) } returns true
-            every { scrapPoseRepository.delete(1L, 10L) } just Runs
-
-            // When
-            useCase.execute(command)
-
-            // Then - 예외 없이 정상 처리
-            verify(exactly = 1) { scrapPoseRepository.delete(1L, 10L) }
-        }
-    })
+        // Then - 예외 없이 정상 처리
+        verify(exactly = 1) { scrapPoseRepository.delete(1L, 10L) }
+    }
+}

--- a/src/test/kotlin/com/neki/pose/application/usecase/UploadPosesUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/UploadPosesUseCaseTest.kt
@@ -7,7 +7,6 @@ import com.neki.pose.application.contract.MediaAvailability
 import com.neki.pose.application.port.MediaClientPort
 import com.neki.pose.application.port.PoseRepositoryPort
 import com.neki.pose.domain.HeadCount
-import com.neki.pose.domain.entity.Pose
 import com.neki.testfixture.FakeTransactionRunner
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
@@ -18,138 +17,139 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 
-class UploadPosesUseCaseTest : FunSpec({
+class UploadPosesUseCaseTest :
+    FunSpec({
 
-    lateinit var mediaClient: MediaClientPort
-    lateinit var poseRepository: PoseRepositoryPort
-    lateinit var transactionRunner: FakeTransactionRunner
-    lateinit var useCase: UploadPosesUseCase
+        lateinit var mediaClient: MediaClientPort
+        lateinit var poseRepository: PoseRepositoryPort
+        lateinit var transactionRunner: FakeTransactionRunner
+        lateinit var useCase: UploadPosesUseCase
 
-    beforeTest {
-        mediaClient = mockk()
-        poseRepository = mockk()
-        transactionRunner = FakeTransactionRunner()
-        useCase = UploadPosesUseCase(mediaClient, transactionRunner, poseRepository)
-    }
-
-    fun makeUploadItem(mediaId: Long, headCount: HeadCount = HeadCount.TWO): UploadPosesCommand.UploadItem =
-        UploadPosesCommand.UploadItem(mediaId = mediaId, headCount = headCount, memo = null)
-
-    fun makeCommand(userId: Long = 1L, uploads: List<UploadPosesCommand.UploadItem>): UploadPosesCommand =
-        UploadPosesCommand(userId = userId, uploads = uploads)
-
-    test("정상 업로드 - 미디어 검증 → pose 저장") {
-        // Given
-        val uploads = listOf(makeUploadItem(101L), makeUploadItem(102L))
-        val command = makeCommand(uploads = uploads)
-
-        every {
-            mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L, 102L))
-        } returns mapOf(101L to MediaAvailability.AVAILABLE, 102L to MediaAvailability.AVAILABLE)
-
-        every { poseRepository.saveAll(any()) } answers { firstArg() }
-
-        // When
-        useCase.execute(command)
-
-        // Then
-        verify(exactly = 1) { poseRepository.saveAll(any()) }
-        verify(exactly = 0) { mediaClient.rollbackMediasUploaded(any(), any()) }
-    }
-
-    test("중복 mediaId → BusinessException(INVALID_PARAMETER)") {
-        // Given: 같은 mediaId가 두 번
-        val uploads = listOf(makeUploadItem(101L), makeUploadItem(101L))
-        val command = makeCommand(uploads = uploads)
-
-        // When / Then
-        val ex = shouldThrow<BusinessException> {
-            useCase.execute(command)
+        beforeTest {
+            mediaClient = mockk()
+            poseRepository = mockk()
+            transactionRunner = FakeTransactionRunner()
+            useCase = UploadPosesUseCase(mediaClient, transactionRunner, poseRepository)
         }
-        ex.resultCode shouldBe ResultCode.INVALID_PARAMETER
-        verify(exactly = 0) { mediaClient.verifyMediasUploaded(any(), any()) }
-    }
 
-    test("일부 미디어 UNAVAILABLE - 사용 가능한 미디어 롤백 후 BusinessException(UPLOAD_FAILED)") {
-        // Given
-        val uploads = listOf(makeUploadItem(101L), makeUploadItem(102L), makeUploadItem(103L))
-        val command = makeCommand(uploads = uploads)
+        fun makeUploadItem(mediaId: Long, headCount: HeadCount = HeadCount.TWO): UploadPosesCommand.UploadItem =
+            UploadPosesCommand.UploadItem(mediaId = mediaId, headCount = headCount, memo = null)
 
-        every {
-            mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L, 102L, 103L))
-        } returns mapOf(
-            101L to MediaAvailability.AVAILABLE,
-            102L to MediaAvailability.UNAVAILABLE,
-            103L to MediaAvailability.AVAILABLE,
-        )
-        every { mediaClient.rollbackMediasUploaded(1L, any()) } just Runs
+        fun makeCommand(userId: Long = 1L, uploads: List<UploadPosesCommand.UploadItem>): UploadPosesCommand =
+            UploadPosesCommand(userId = userId, uploads = uploads)
 
-        // When / Then
-        val ex = shouldThrow<BusinessException> {
+        test("정상 업로드 - 미디어 검증 → pose 저장") {
+            // Given
+            val uploads = listOf(makeUploadItem(101L), makeUploadItem(102L))
+            val command = makeCommand(uploads = uploads)
+
+            every {
+                mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L, 102L))
+            } returns mapOf(101L to MediaAvailability.AVAILABLE, 102L to MediaAvailability.AVAILABLE)
+
+            every { poseRepository.saveAll(any()) } answers { firstArg() }
+
+            // When
             useCase.execute(command)
+
+            // Then
+            verify(exactly = 1) { poseRepository.saveAll(any()) }
+            verify(exactly = 0) { mediaClient.rollbackMediasUploaded(any(), any()) }
         }
-        ex.resultCode shouldBe ResultCode.UPLOAD_FAILED
-        // 성공한 미디어 101, 103 롤백 확인
-        verify(exactly = 1) { mediaClient.rollbackMediasUploaded(eq(1L), any()) }
-        verify(exactly = 0) { poseRepository.saveAll(any()) }
-    }
 
-    test("트랜잭션 실패 → 롤백 - 미디어 rollback 호출 확인") {
-        // Given
-        val uploads = listOf(makeUploadItem(101L), makeUploadItem(102L))
-        val command = makeCommand(uploads = uploads)
+        test("중복 mediaId → BusinessException(INVALID_PARAMETER)") {
+            // Given: 같은 mediaId가 두 번
+            val uploads = listOf(makeUploadItem(101L), makeUploadItem(101L))
+            val command = makeCommand(uploads = uploads)
 
-        every {
-            mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L, 102L))
-        } returns mapOf(101L to MediaAvailability.AVAILABLE, 102L to MediaAvailability.AVAILABLE)
+            // When / Then
+            val ex = shouldThrow<BusinessException> {
+                useCase.execute(command)
+            }
+            ex.resultCode shouldBe ResultCode.INVALID_PARAMETER
+            verify(exactly = 0) { mediaClient.verifyMediasUploaded(any(), any()) }
+        }
 
-        every { poseRepository.saveAll(any()) } throws RuntimeException("DB 저장 실패")
-        every { mediaClient.rollbackMediasUploaded(1L, listOf(101L, 102L)) } just Runs
+        test("일부 미디어 UNAVAILABLE - 사용 가능한 미디어 롤백 후 BusinessException(UPLOAD_FAILED)") {
+            // Given
+            val uploads = listOf(makeUploadItem(101L), makeUploadItem(102L), makeUploadItem(103L))
+            val command = makeCommand(uploads = uploads)
 
-        // When / Then
-        shouldThrow<RuntimeException> {
+            every {
+                mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L, 102L, 103L))
+            } returns mapOf(
+                101L to MediaAvailability.AVAILABLE,
+                102L to MediaAvailability.UNAVAILABLE,
+                103L to MediaAvailability.AVAILABLE,
+            )
+            every { mediaClient.rollbackMediasUploaded(1L, any()) } just Runs
+
+            // When / Then
+            val ex = shouldThrow<BusinessException> {
+                useCase.execute(command)
+            }
+            ex.resultCode shouldBe ResultCode.UPLOAD_FAILED
+            // 성공한 미디어 101, 103 롤백 확인
+            verify(exactly = 1) { mediaClient.rollbackMediasUploaded(eq(1L), any()) }
+            verify(exactly = 0) { poseRepository.saveAll(any()) }
+        }
+
+        test("트랜잭션 실패 → 롤백 - 미디어 rollback 호출 확인") {
+            // Given
+            val uploads = listOf(makeUploadItem(101L), makeUploadItem(102L))
+            val command = makeCommand(uploads = uploads)
+
+            every {
+                mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L, 102L))
+            } returns mapOf(101L to MediaAvailability.AVAILABLE, 102L to MediaAvailability.AVAILABLE)
+
+            every { poseRepository.saveAll(any()) } throws RuntimeException("DB 저장 실패")
+            every { mediaClient.rollbackMediasUploaded(1L, listOf(101L, 102L)) } just Runs
+
+            // When / Then
+            shouldThrow<RuntimeException> {
+                useCase.execute(command)
+            }
+            verify(exactly = 1) { mediaClient.rollbackMediasUploaded(1L, listOf(101L, 102L)) }
+        }
+
+        test("롤백 중 예외 발생 - 롤백 예외가 전파됨") {
+            // Given
+            val uploads = listOf(makeUploadItem(101L))
+            val command = makeCommand(uploads = uploads)
+            val originalException = RuntimeException("원래 예외")
+            val rollbackException = RuntimeException("롤백 실패")
+
+            every {
+                mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L))
+            } returns mapOf(101L to MediaAvailability.AVAILABLE)
+
+            every { poseRepository.saveAll(any()) } throws originalException
+            every { mediaClient.rollbackMediasUploaded(1L, listOf(101L)) } throws rollbackException
+
+            // When / Then
+            // rollback 중 예외가 발생하면 rollback 예외가 전파됨 (원래 예외는 catch 블록 안에서 소실)
+            val ex = shouldThrow<RuntimeException> {
+                useCase.execute(command)
+            }
+            ex.message shouldBe "롤백 실패"
+        }
+
+        test("빈 uploads 목록 - 저장 0건 정상 처리") {
+            // Given
+            val command = makeCommand(uploads = emptyList())
+
+            every {
+                mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = emptyList())
+            } returns emptyMap()
+
+            every { poseRepository.saveAll(emptyList()) } returns emptyList()
+
+            // When
             useCase.execute(command)
+
+            // Then
+            verify(exactly = 1) { poseRepository.saveAll(emptyList()) }
+            verify(exactly = 0) { mediaClient.rollbackMediasUploaded(any(), any()) }
         }
-        verify(exactly = 1) { mediaClient.rollbackMediasUploaded(1L, listOf(101L, 102L)) }
-    }
-
-    test("롤백 중 예외 발생 - 롤백 예외가 전파됨") {
-        // Given
-        val uploads = listOf(makeUploadItem(101L))
-        val command = makeCommand(uploads = uploads)
-        val originalException = RuntimeException("원래 예외")
-        val rollbackException = RuntimeException("롤백 실패")
-
-        every {
-            mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L))
-        } returns mapOf(101L to MediaAvailability.AVAILABLE)
-
-        every { poseRepository.saveAll(any()) } throws originalException
-        every { mediaClient.rollbackMediasUploaded(1L, listOf(101L)) } throws rollbackException
-
-        // When / Then
-        // rollback 중 예외가 발생하면 rollback 예외가 전파됨 (원래 예외는 catch 블록 안에서 소실)
-        val ex = shouldThrow<RuntimeException> {
-            useCase.execute(command)
-        }
-        ex.message shouldBe "롤백 실패"
-    }
-
-    test("빈 uploads 목록 - 저장 0건 정상 처리") {
-        // Given
-        val command = makeCommand(uploads = emptyList())
-
-        every {
-            mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = emptyList())
-        } returns emptyMap()
-
-        every { poseRepository.saveAll(emptyList()) } returns emptyList()
-
-        // When
-        useCase.execute(command)
-
-        // Then
-        verify(exactly = 1) { poseRepository.saveAll(emptyList()) }
-        verify(exactly = 0) { mediaClient.rollbackMediasUploaded(any(), any()) }
-    }
-})
+    })

--- a/src/test/kotlin/com/neki/pose/application/usecase/UploadPosesUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/UploadPosesUseCaseTest.kt
@@ -1,0 +1,153 @@
+package com.neki.pose.application.usecase
+
+import com.neki.common.api.dto.ResultCode
+import com.neki.common.exception.BusinessException
+import com.neki.pose.application.command.UploadPosesCommand
+import com.neki.pose.application.contract.MediaAvailability
+import com.neki.pose.application.port.MediaClientPort
+import com.neki.pose.application.port.PoseRepositoryPort
+import com.neki.pose.domain.HeadCount
+import com.neki.pose.domain.entity.Pose
+import com.neki.testfixture.FakeTransactionRunner
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+
+class UploadPosesUseCaseTest : FunSpec({
+
+    lateinit var mediaClient: MediaClientPort
+    lateinit var poseRepository: PoseRepositoryPort
+    lateinit var transactionRunner: FakeTransactionRunner
+    lateinit var useCase: UploadPosesUseCase
+
+    beforeTest {
+        mediaClient = mockk()
+        poseRepository = mockk()
+        transactionRunner = FakeTransactionRunner()
+        useCase = UploadPosesUseCase(mediaClient, transactionRunner, poseRepository)
+    }
+
+    fun makeUploadItem(mediaId: Long, headCount: HeadCount = HeadCount.TWO): UploadPosesCommand.UploadItem =
+        UploadPosesCommand.UploadItem(mediaId = mediaId, headCount = headCount, memo = null)
+
+    fun makeCommand(userId: Long = 1L, uploads: List<UploadPosesCommand.UploadItem>): UploadPosesCommand =
+        UploadPosesCommand(userId = userId, uploads = uploads)
+
+    test("정상 업로드 - 미디어 검증 → pose 저장") {
+        // Given
+        val uploads = listOf(makeUploadItem(101L), makeUploadItem(102L))
+        val command = makeCommand(uploads = uploads)
+
+        every {
+            mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L, 102L))
+        } returns mapOf(101L to MediaAvailability.AVAILABLE, 102L to MediaAvailability.AVAILABLE)
+
+        every { poseRepository.saveAll(any()) } answers { firstArg() }
+
+        // When
+        useCase.execute(command)
+
+        // Then
+        verify(exactly = 1) { poseRepository.saveAll(any()) }
+        verify(exactly = 0) { mediaClient.rollbackMediasUploaded(any(), any()) }
+    }
+
+    test("중복 mediaId → BusinessException(INVALID_PARAMETER)") {
+        // Given: 같은 mediaId가 두 번
+        val uploads = listOf(makeUploadItem(101L), makeUploadItem(101L))
+        val command = makeCommand(uploads = uploads)
+
+        // When / Then
+        val ex = shouldThrow<BusinessException> {
+            useCase.execute(command)
+        }
+        ex.resultCode shouldBe ResultCode.INVALID_PARAMETER
+        verify(exactly = 0) { mediaClient.verifyMediasUploaded(any(), any()) }
+    }
+
+    test("일부 미디어 UNAVAILABLE - 사용 가능한 미디어 롤백 후 BusinessException(UPLOAD_FAILED)") {
+        // Given
+        val uploads = listOf(makeUploadItem(101L), makeUploadItem(102L), makeUploadItem(103L))
+        val command = makeCommand(uploads = uploads)
+
+        every {
+            mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L, 102L, 103L))
+        } returns mapOf(
+            101L to MediaAvailability.AVAILABLE,
+            102L to MediaAvailability.UNAVAILABLE,
+            103L to MediaAvailability.AVAILABLE,
+        )
+        every { mediaClient.rollbackMediasUploaded(1L, any()) } just Runs
+
+        // When / Then
+        val ex = shouldThrow<BusinessException> {
+            useCase.execute(command)
+        }
+        ex.resultCode shouldBe ResultCode.UPLOAD_FAILED
+        // 성공한 미디어 101, 103 롤백 확인
+        verify(exactly = 1) { mediaClient.rollbackMediasUploaded(eq(1L), any()) }
+        verify(exactly = 0) { poseRepository.saveAll(any()) }
+    }
+
+    test("트랜잭션 실패 → 롤백 - 미디어 rollback 호출 확인") {
+        // Given
+        val uploads = listOf(makeUploadItem(101L), makeUploadItem(102L))
+        val command = makeCommand(uploads = uploads)
+
+        every {
+            mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L, 102L))
+        } returns mapOf(101L to MediaAvailability.AVAILABLE, 102L to MediaAvailability.AVAILABLE)
+
+        every { poseRepository.saveAll(any()) } throws RuntimeException("DB 저장 실패")
+        every { mediaClient.rollbackMediasUploaded(1L, listOf(101L, 102L)) } just Runs
+
+        // When / Then
+        shouldThrow<RuntimeException> {
+            useCase.execute(command)
+        }
+        verify(exactly = 1) { mediaClient.rollbackMediasUploaded(1L, listOf(101L, 102L)) }
+    }
+
+    test("롤백 중 예외 발생 - 원래 예외가 전파됨") {
+        // Given
+        val uploads = listOf(makeUploadItem(101L))
+        val command = makeCommand(uploads = uploads)
+        val originalException = RuntimeException("원래 예외")
+
+        every {
+            mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L))
+        } returns mapOf(101L to MediaAvailability.AVAILABLE)
+
+        every { poseRepository.saveAll(any()) } throws originalException
+        every { mediaClient.rollbackMediasUploaded(1L, listOf(101L)) } throws RuntimeException("롤백 실패")
+
+        // When / Then
+        // rollback 예외가 발생해도 원래 예외의 타입이 전파됨
+        shouldThrow<RuntimeException> {
+            useCase.execute(command)
+        }
+    }
+
+    test("빈 uploads 목록 - 저장 0건 정상 처리") {
+        // Given
+        val command = makeCommand(uploads = emptyList())
+
+        every {
+            mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = emptyList())
+        } returns emptyMap()
+
+        every { poseRepository.saveAll(emptyList()) } returns emptyList()
+
+        // When
+        useCase.execute(command)
+
+        // Then
+        verify(exactly = 1) { poseRepository.saveAll(emptyList()) }
+        verify(exactly = 0) { mediaClient.rollbackMediasUploaded(any(), any()) }
+    }
+})

--- a/src/test/kotlin/com/neki/pose/application/usecase/UploadPosesUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/UploadPosesUseCaseTest.kt
@@ -9,147 +9,161 @@ import com.neki.pose.application.port.PoseRepositoryPort
 import com.neki.pose.domain.HeadCount
 import com.neki.testfixture.FakeTransactionRunner
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-class UploadPosesUseCaseTest :
-    FunSpec({
+class UploadPosesUseCaseTest {
 
-        lateinit var mediaClient: MediaClientPort
-        lateinit var poseRepository: PoseRepositoryPort
-        lateinit var transactionRunner: FakeTransactionRunner
-        lateinit var useCase: UploadPosesUseCase
+    private lateinit var mediaClient: MediaClientPort
+    private lateinit var poseRepository: PoseRepositoryPort
+    private lateinit var transactionRunner: FakeTransactionRunner
+    private lateinit var useCase: UploadPosesUseCase
 
-        beforeTest {
-            mediaClient = mockk()
-            poseRepository = mockk()
-            transactionRunner = FakeTransactionRunner()
-            useCase = UploadPosesUseCase(mediaClient, transactionRunner, poseRepository)
-        }
+    @BeforeEach
+    fun setUp() {
+        mediaClient = mockk()
+        poseRepository = mockk()
+        transactionRunner = FakeTransactionRunner()
+        useCase = UploadPosesUseCase(mediaClient, transactionRunner, poseRepository)
+    }
 
-        fun makeUploadItem(mediaId: Long, headCount: HeadCount = HeadCount.TWO): UploadPosesCommand.UploadItem =
-            UploadPosesCommand.UploadItem(mediaId = mediaId, headCount = headCount, memo = null)
+    private fun makeUploadItem(mediaId: Long, headCount: HeadCount = HeadCount.TWO): UploadPosesCommand.UploadItem =
+        UploadPosesCommand.UploadItem(mediaId = mediaId, headCount = headCount, memo = null)
 
-        fun makeCommand(userId: Long = 1L, uploads: List<UploadPosesCommand.UploadItem>): UploadPosesCommand =
-            UploadPosesCommand(userId = userId, uploads = uploads)
+    private fun makeCommand(userId: Long = 1L, uploads: List<UploadPosesCommand.UploadItem>): UploadPosesCommand =
+        UploadPosesCommand(userId = userId, uploads = uploads)
 
-        test("정상 업로드 - 미디어 검증 → pose 저장") {
-            // Given
-            val uploads = listOf(makeUploadItem(101L), makeUploadItem(102L))
-            val command = makeCommand(uploads = uploads)
+    @Test
+    @DisplayName("정상 업로드 - 미디어 검증 → pose 저장")
+    fun `정상 업로드 - 미디어 검증 → pose 저장`() {
+        // Given
+        val uploads = listOf(makeUploadItem(101L), makeUploadItem(102L))
+        val command = makeCommand(uploads = uploads)
 
-            every {
-                mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L, 102L))
-            } returns mapOf(101L to MediaAvailability.AVAILABLE, 102L to MediaAvailability.AVAILABLE)
+        every {
+            mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L, 102L))
+        } returns mapOf(101L to MediaAvailability.AVAILABLE, 102L to MediaAvailability.AVAILABLE)
 
-            every { poseRepository.saveAll(any()) } answers { firstArg() }
+        every { poseRepository.saveAll(any()) } answers { firstArg() }
 
-            // When
+        // When
+        useCase.execute(command)
+
+        // Then
+        verify(exactly = 1) { poseRepository.saveAll(any()) }
+        verify(exactly = 0) { mediaClient.rollbackMediasUploaded(any(), any()) }
+    }
+
+    @Test
+    @DisplayName("중복 mediaId → BusinessException(INVALID_PARAMETER)")
+    fun `중복 mediaId → BusinessException(INVALID_PARAMETER)`() {
+        // Given: 같은 mediaId가 두 번
+        val uploads = listOf(makeUploadItem(101L), makeUploadItem(101L))
+        val command = makeCommand(uploads = uploads)
+
+        // When / Then
+        val ex = shouldThrow<BusinessException> {
             useCase.execute(command)
-
-            // Then
-            verify(exactly = 1) { poseRepository.saveAll(any()) }
-            verify(exactly = 0) { mediaClient.rollbackMediasUploaded(any(), any()) }
         }
+        ex.resultCode shouldBe ResultCode.INVALID_PARAMETER
+        verify(exactly = 0) { mediaClient.verifyMediasUploaded(any(), any()) }
+    }
 
-        test("중복 mediaId → BusinessException(INVALID_PARAMETER)") {
-            // Given: 같은 mediaId가 두 번
-            val uploads = listOf(makeUploadItem(101L), makeUploadItem(101L))
-            val command = makeCommand(uploads = uploads)
+    @Test
+    @DisplayName("일부 미디어 UNAVAILABLE - 사용 가능한 미디어 롤백 후 BusinessException(UPLOAD_FAILED)")
+    fun `일부 미디어 UNAVAILABLE - 사용 가능한 미디어 롤백 후 BusinessException(UPLOAD_FAILED)`() {
+        // Given
+        val uploads = listOf(makeUploadItem(101L), makeUploadItem(102L), makeUploadItem(103L))
+        val command = makeCommand(uploads = uploads)
 
-            // When / Then
-            val ex = shouldThrow<BusinessException> {
-                useCase.execute(command)
-            }
-            ex.resultCode shouldBe ResultCode.INVALID_PARAMETER
-            verify(exactly = 0) { mediaClient.verifyMediasUploaded(any(), any()) }
-        }
+        every {
+            mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L, 102L, 103L))
+        } returns mapOf(
+            101L to MediaAvailability.AVAILABLE,
+            102L to MediaAvailability.UNAVAILABLE,
+            103L to MediaAvailability.AVAILABLE,
+        )
+        every { mediaClient.rollbackMediasUploaded(1L, any()) } just Runs
 
-        test("일부 미디어 UNAVAILABLE - 사용 가능한 미디어 롤백 후 BusinessException(UPLOAD_FAILED)") {
-            // Given
-            val uploads = listOf(makeUploadItem(101L), makeUploadItem(102L), makeUploadItem(103L))
-            val command = makeCommand(uploads = uploads)
-
-            every {
-                mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L, 102L, 103L))
-            } returns mapOf(
-                101L to MediaAvailability.AVAILABLE,
-                102L to MediaAvailability.UNAVAILABLE,
-                103L to MediaAvailability.AVAILABLE,
-            )
-            every { mediaClient.rollbackMediasUploaded(1L, any()) } just Runs
-
-            // When / Then
-            val ex = shouldThrow<BusinessException> {
-                useCase.execute(command)
-            }
-            ex.resultCode shouldBe ResultCode.UPLOAD_FAILED
-            // 성공한 미디어 101, 103 롤백 확인
-            verify(exactly = 1) { mediaClient.rollbackMediasUploaded(eq(1L), any()) }
-            verify(exactly = 0) { poseRepository.saveAll(any()) }
-        }
-
-        test("트랜잭션 실패 → 롤백 - 미디어 rollback 호출 확인") {
-            // Given
-            val uploads = listOf(makeUploadItem(101L), makeUploadItem(102L))
-            val command = makeCommand(uploads = uploads)
-
-            every {
-                mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L, 102L))
-            } returns mapOf(101L to MediaAvailability.AVAILABLE, 102L to MediaAvailability.AVAILABLE)
-
-            every { poseRepository.saveAll(any()) } throws RuntimeException("DB 저장 실패")
-            every { mediaClient.rollbackMediasUploaded(1L, listOf(101L, 102L)) } just Runs
-
-            // When / Then
-            shouldThrow<RuntimeException> {
-                useCase.execute(command)
-            }
-            verify(exactly = 1) { mediaClient.rollbackMediasUploaded(1L, listOf(101L, 102L)) }
-        }
-
-        test("롤백 중 예외 발생 - 롤백 예외가 전파됨") {
-            // Given
-            val uploads = listOf(makeUploadItem(101L))
-            val command = makeCommand(uploads = uploads)
-            val originalException = RuntimeException("원래 예외")
-            val rollbackException = RuntimeException("롤백 실패")
-
-            every {
-                mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L))
-            } returns mapOf(101L to MediaAvailability.AVAILABLE)
-
-            every { poseRepository.saveAll(any()) } throws originalException
-            every { mediaClient.rollbackMediasUploaded(1L, listOf(101L)) } throws rollbackException
-
-            // When / Then
-            // rollback 중 예외가 발생하면 rollback 예외가 전파됨 (원래 예외는 catch 블록 안에서 소실)
-            val ex = shouldThrow<RuntimeException> {
-                useCase.execute(command)
-            }
-            ex.message shouldBe "롤백 실패"
-        }
-
-        test("빈 uploads 목록 - 저장 0건 정상 처리") {
-            // Given
-            val command = makeCommand(uploads = emptyList())
-
-            every {
-                mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = emptyList())
-            } returns emptyMap()
-
-            every { poseRepository.saveAll(emptyList()) } returns emptyList()
-
-            // When
+        // When / Then
+        val ex = shouldThrow<BusinessException> {
             useCase.execute(command)
-
-            // Then
-            verify(exactly = 1) { poseRepository.saveAll(emptyList()) }
-            verify(exactly = 0) { mediaClient.rollbackMediasUploaded(any(), any()) }
         }
-    })
+        ex.resultCode shouldBe ResultCode.UPLOAD_FAILED
+        // 성공한 미디어 101, 103 롤백 확인
+        verify(exactly = 1) { mediaClient.rollbackMediasUploaded(eq(1L), any()) }
+        verify(exactly = 0) { poseRepository.saveAll(any()) }
+    }
+
+    @Test
+    @DisplayName("트랜잭션 실패 → 롤백 - 미디어 rollback 호출 확인")
+    fun `트랜잭션 실패 → 롤백 - 미디어 rollback 호출 확인`() {
+        // Given
+        val uploads = listOf(makeUploadItem(101L), makeUploadItem(102L))
+        val command = makeCommand(uploads = uploads)
+
+        every {
+            mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L, 102L))
+        } returns mapOf(101L to MediaAvailability.AVAILABLE, 102L to MediaAvailability.AVAILABLE)
+
+        every { poseRepository.saveAll(any()) } throws RuntimeException("DB 저장 실패")
+        every { mediaClient.rollbackMediasUploaded(1L, listOf(101L, 102L)) } just Runs
+
+        // When / Then
+        shouldThrow<RuntimeException> {
+            useCase.execute(command)
+        }
+        verify(exactly = 1) { mediaClient.rollbackMediasUploaded(1L, listOf(101L, 102L)) }
+    }
+
+    @Test
+    @DisplayName("롤백 중 예외 발생 - 롤백 예외가 전파됨")
+    fun `롤백 중 예외 발생 - 롤백 예외가 전파됨`() {
+        // Given
+        val uploads = listOf(makeUploadItem(101L))
+        val command = makeCommand(uploads = uploads)
+        val originalException = RuntimeException("원래 예외")
+        val rollbackException = RuntimeException("롤백 실패")
+
+        every {
+            mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L))
+        } returns mapOf(101L to MediaAvailability.AVAILABLE)
+
+        every { poseRepository.saveAll(any()) } throws originalException
+        every { mediaClient.rollbackMediasUploaded(1L, listOf(101L)) } throws rollbackException
+
+        // When / Then
+        // rollback 중 예외가 발생하면 rollback 예외가 전파됨 (원래 예외는 catch 블록 안에서 소실)
+        val ex = shouldThrow<RuntimeException> {
+            useCase.execute(command)
+        }
+        ex.message shouldBe "롤백 실패"
+    }
+
+    @Test
+    @DisplayName("빈 uploads 목록 - 저장 0건 정상 처리")
+    fun `빈 uploads 목록 - 저장 0건 정상 처리`() {
+        // Given
+        val command = makeCommand(uploads = emptyList())
+
+        every {
+            mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = emptyList())
+        } returns emptyMap()
+
+        every { poseRepository.saveAll(emptyList()) } returns emptyList()
+
+        // When
+        useCase.execute(command)
+
+        // Then
+        verify(exactly = 1) { poseRepository.saveAll(emptyList()) }
+        verify(exactly = 0) { mediaClient.rollbackMediasUploaded(any(), any()) }
+    }
+}

--- a/src/test/kotlin/com/neki/pose/application/usecase/UploadPosesUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/pose/application/usecase/UploadPosesUseCaseTest.kt
@@ -113,24 +113,26 @@ class UploadPosesUseCaseTest : FunSpec({
         verify(exactly = 1) { mediaClient.rollbackMediasUploaded(1L, listOf(101L, 102L)) }
     }
 
-    test("롤백 중 예외 발생 - 원래 예외가 전파됨") {
+    test("롤백 중 예외 발생 - 롤백 예외가 전파됨") {
         // Given
         val uploads = listOf(makeUploadItem(101L))
         val command = makeCommand(uploads = uploads)
         val originalException = RuntimeException("원래 예외")
+        val rollbackException = RuntimeException("롤백 실패")
 
         every {
             mediaClient.verifyMediasUploaded(ownerId = 1L, mediaIds = listOf(101L))
         } returns mapOf(101L to MediaAvailability.AVAILABLE)
 
         every { poseRepository.saveAll(any()) } throws originalException
-        every { mediaClient.rollbackMediasUploaded(1L, listOf(101L)) } throws RuntimeException("롤백 실패")
+        every { mediaClient.rollbackMediasUploaded(1L, listOf(101L)) } throws rollbackException
 
         // When / Then
-        // rollback 예외가 발생해도 원래 예외의 타입이 전파됨
-        shouldThrow<RuntimeException> {
+        // rollback 중 예외가 발생하면 rollback 예외가 전파됨 (원래 예외는 catch 블록 안에서 소실)
+        val ex = shouldThrow<RuntimeException> {
             useCase.execute(command)
         }
+        ex.message shouldBe "롤백 실패"
     }
 
     test("빈 uploads 목록 - 저장 0건 정상 처리") {


### PR DESCRIPTION
## Summary
- UpdatePoseScrapUseCase: 5개 테스트 (스크랩 토글, 멱등성)
- GetPosesUseCase: 6개 테스트 (hasNext, 미디어 미존재 필터링)
- GetScrapPosesUseCase: 4개 테스트
- GetPoseUseCase: 5개 테스트 (조회수 캐시, 장애 처리)
- RandomPoseUseCase: 5개 테스트 (race condition, count=1)
- UploadPosesUseCase: 6개 테스트 (롤백, 빈 목록)

총 31개 테스트

closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)