### PR TITLE
chore/#276: TB_PHOTO_IMAGE_FOLDER folderId 필드 null허용

### DIFF
--- a/src/main/kotlin/com/neki/photo/application/port/PhotoImageFolderRepositoryPort.kt
+++ b/src/main/kotlin/com/neki/photo/application/port/PhotoImageFolderRepositoryPort.kt
@@ -4,9 +4,9 @@ import com.neki.photo.domain.entity.PhotoImageFolder
 
 interface PhotoImageFolderRepositoryPort {
 
-    fun saveAll(photoImageIds: List<Long>, folderId: Long)
+    fun saveAll(photoImageIds: List<Long>, folderId: Long?)
 
-    fun saveAll(mappings: List<Pair<Long, Long>>)
+    fun saveAll(mappings: List<Pair<Long, Long?>>)
 
     fun deleteByPhotoImageIds(photoImageIds: List<Long>)
 

--- a/src/main/kotlin/com/neki/photo/application/usecase/CopyPhotosToFolderUseCase.kt
+++ b/src/main/kotlin/com/neki/photo/application/usecase/CopyPhotosToFolderUseCase.kt
@@ -39,12 +39,12 @@ class CopyPhotosToFolderUseCase(
         }
 
         // 멱등성 보장: target 폴더들에 이미 존재하는 (사진, 폴더) 매핑을 한번에 조회
-        val existingPairs: Set<Pair<Long, Long>> =
+        val existingPairs: Set<Pair<Long, Long?>> =
             photoImageFolderRepository.findByPhotoImageIdsAndFolderIds(command.photoIds, command.targetFolderIds)
                 .map { it.photoImageId to it.folderId }
                 .toSet()
 
-        val newMappings: List<Pair<Long, Long>> = command.targetFolderIds.flatMap { folderId ->
+        val newMappings: List<Pair<Long, Long?>> = command.targetFolderIds.flatMap { folderId ->
             command.photoIds
                 .filter { photoId -> (photoId to folderId) !in existingPairs }
                 .map { photoId -> photoId to folderId }

--- a/src/main/kotlin/com/neki/photo/application/usecase/MovePhotosToFolderUseCase.kt
+++ b/src/main/kotlin/com/neki/photo/application/usecase/MovePhotosToFolderUseCase.kt
@@ -46,12 +46,12 @@ class MovePhotosToFolderUseCase(
         }
 
         // 멱등성 보장: target 폴더들에 이미 존재하는 (사진, 폴더) 매핑을 한번에 조회
-        val existingPairs: Set<Pair<Long, Long>> =
+        val existingPairs: Set<Pair<Long, Long?>> =
             photoImageFolderRepository.findByPhotoImageIdsAndFolderIds(command.photoIds, command.targetFolderIds)
                 .map { it.photoImageId to it.folderId }
                 .toSet()
 
-        val newMappings: List<Pair<Long, Long>> = command.targetFolderIds.flatMap { folderId ->
+        val newMappings: List<Pair<Long, Long?>> = command.targetFolderIds.flatMap { folderId ->
             command.photoIds
                 .filter { photoId -> (photoId to folderId) !in existingPairs }
                 .map { photoId -> photoId to folderId }

--- a/src/main/kotlin/com/neki/photo/application/usecase/UploadPhotosUseCase.kt
+++ b/src/main/kotlin/com/neki/photo/application/usecase/UploadPhotosUseCase.kt
@@ -59,9 +59,7 @@ class UploadPhotosUseCase(
             transactionRunner.run {
                 val savedPhotos: List<PhotoImage> = photoImageRepository.saveAll(photos)
                 val savedPhotoIds: List<Long> = savedPhotos.map { it.id!! }
-                if (command.folderId != null) {
-                    photoImageFolderRepository.saveAll(savedPhotoIds, command.folderId)
-                }
+                photoImageFolderRepository.saveAll(savedPhotoIds, command.folderId)
                 if (command.favorite) {
                     favoriteImageRepository.addAll(command.userId, savedPhotoIds)
                 }

--- a/src/main/kotlin/com/neki/photo/domain/entity/PhotoImageFolder.kt
+++ b/src/main/kotlin/com/neki/photo/domain/entity/PhotoImageFolder.kt
@@ -18,6 +18,6 @@ class PhotoImageFolder(
     @Column(name = "photo_image_id", nullable = false)
     val photoImageId: Long,
 
-    @Column(name = "folder_id", nullable = false)
-    val folderId: Long,
+    @Column(name = "folder_id", nullable = true)
+    val folderId: Long?,
 ) : BaseTimeEntity()

--- a/src/main/kotlin/com/neki/photo/infra/persist/PhotoImageFolderRepositoryAdapter.kt
+++ b/src/main/kotlin/com/neki/photo/infra/persist/PhotoImageFolderRepositoryAdapter.kt
@@ -9,13 +9,13 @@ import org.springframework.stereotype.Repository
 class PhotoImageFolderRepositoryAdapter(private val jpaRepository: JpaPhotoImageFolderRepository) :
     PhotoImageFolderRepositoryPort {
 
-    override fun saveAll(photoImageIds: List<Long>, folderId: Long) {
+    override fun saveAll(photoImageIds: List<Long>, folderId: Long?) {
         if (photoImageIds.isEmpty()) return
         val entities = photoImageIds.map { PhotoImageFolder(photoImageId = it, folderId = folderId) }
         jpaRepository.saveAll(entities)
     }
 
-    override fun saveAll(mappings: List<Pair<Long, Long>>) {
+    override fun saveAll(mappings: List<Pair<Long, Long?>>) {
         if (mappings.isEmpty()) return
         val entities: List<PhotoImageFolder> = mappings.map { (photoImageId, folderId) ->
             PhotoImageFolder(photoImageId = photoImageId, folderId = folderId)

--- a/src/main/resources/db/migration/V19__allow_null_folder_id_and_backfill_orphan_photos.sql
+++ b/src/main/resources/db/migration/V19__allow_null_folder_id_and_backfill_orphan_photos.sql
@@ -1,0 +1,22 @@
+-- 1. folder_id NULL 허용으로 변경
+ALTER TABLE tb_photo_image_folder
+    ALTER COLUMN folder_id DROP NOT NULL;
+
+-- 2. 기존 unique constraint 삭제 (photo_image_id, folder_id 조합)
+-- folder_id가 NULL이면 unique 동작이 달라지므로 삭제
+ALTER TABLE tb_photo_image_folder
+    DROP CONSTRAINT IF EXISTS uk_photo_image_folder;
+
+-- 3. photo_image에 있지만 photo_image_folder에 없는 것들 삽입
+INSERT INTO tb_photo_image_folder (photo_image_id, folder_id, created_at, updated_at)
+SELECT
+    pi.id,
+    NULL,
+    pi.created_at,
+    pi.updated_at
+FROM tb_photo_image pi
+WHERE NOT EXISTS (
+    SELECT 1 FROM tb_photo_image_folder pif
+    WHERE pif.photo_image_id = pi.id
+)
+  AND pi.deleted_at IS NULL;

--- a/src/test/kotlin/com/neki/photo/application/usecase/UploadPhotosUseCaseTest.kt
+++ b/src/test/kotlin/com/neki/photo/application/usecase/UploadPhotosUseCaseTest.kt
@@ -175,6 +175,7 @@ class UploadPhotosUseCaseTest {
         every { mediaClient.verifyMediasUploaded(1L, listOf(20L)) } returns
             mapOf(20L to MediaAvailability.AVAILABLE)
         every { photoImageRepository.saveAll(any()) } returns savedPhotos
+        every { photoImageFolderRepository.saveAll(listOf(200L), null) } just Runs
 
         // When
         useCase.execute(command)
@@ -182,6 +183,7 @@ class UploadPhotosUseCaseTest {
         // Then
         verify(exactly = 1) { mediaClient.verifyMediasUploaded(1L, listOf(20L)) }
         verify(exactly = 1) { photoImageRepository.saveAll(match { it.size == 1 && it[0].mediaId == 20L }) }
+        verify(exactly = 1) { photoImageFolderRepository.saveAll(listOf(200L), null) }
     }
 
     @Test
@@ -202,8 +204,8 @@ class UploadPhotosUseCaseTest {
     }
 
     @Test
-    @DisplayName("folderId가 null이면 폴더 연결 없이 사진만 저장")
-    fun `folderId가 null이면 폴더 연결 없이 사진만 저장`() {
+    @DisplayName("folderId가 null이면 폴더 없이 photo_image_folder에 저장")
+    fun `folderId가 null이면 폴더 없이 photo_image_folder에 저장`() {
         // Given
         val uploads = listOf(makeUploadItem(10L))
         val command = UploadPhotoCommand(userId = 1L, folderId = null, uploads = uploads, favorite = false)
@@ -213,13 +215,14 @@ class UploadPhotosUseCaseTest {
         every { mediaClient.verifyMediasUploaded(1L, listOf(10L)) } returns
             mapOf(10L to MediaAvailability.AVAILABLE)
         every { photoImageRepository.saveAll(any()) } returns savedPhotos
+        every { photoImageFolderRepository.saveAll(listOf(100L), null) } just Runs
 
         // When
         useCase.execute(command)
 
         // Then
         verify(exactly = 1) { photoImageRepository.saveAll(any()) }
-        verify(exactly = 0) { photoImageFolderRepository.saveAll(any(), any()) }
+        verify(exactly = 1) { photoImageFolderRepository.saveAll(listOf(100L), null) }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- 기획적 기능 변경으류 인해 photo_image_folder내 외래키 제약조건 해제
- folder_id nullable로 변경

## Changes
- `TB_PHOTO_IMAGE_FOLDER` 테이블 folderId 필드 null 허용
- 기존 사진 업로드 API에 folderId null insert 가능하도록 변경

## Related Issue
#276 