### PR TITLE
fix/#279: 사진 이동/복제 API 수정

### DIFF
--- a/src/main/kotlin/com/neki/photo/api/converter/FolderCommandConverter.kt
+++ b/src/main/kotlin/com/neki/photo/api/converter/FolderCommandConverter.kt
@@ -39,8 +39,8 @@ class FolderCommandConverter {
         RemovePhotosFromFolderCommand(userId, folderId, request.photoIds)
 
     fun toMovePhotosToFolderCommand(request: MovePhotosToFolderRequest, userId: Long) =
-        MovePhotosToFolderCommand(userId, request.sourceFolderId, request.photoIds, request.targetFolderIds)
+        MovePhotosToFolderCommand(userId, request.sourceFolderId!!, request.photoIds, request.targetFolderIds)
 
     fun toCopyPhotosToFolderCommand(request: CopyPhotosToFolderRequest, userId: Long) =
-        CopyPhotosToFolderCommand(userId, request.sourceFolderId!!, request.photoIds, request.targetFolderIds)
+        CopyPhotosToFolderCommand(userId, request.photoIds, request.targetFolderIds)
 }

--- a/src/main/kotlin/com/neki/photo/api/dto/FolderRequest.kt
+++ b/src/main/kotlin/com/neki/photo/api/dto/FolderRequest.kt
@@ -46,10 +46,10 @@ data class RemovePhotosFromFolderRequest(
 
 data class MovePhotosToFolderRequest(
     @field:Schema(
-        description = "이동하기 전 폴더 ID 없으면 null",
+        description = "이동전 폴더 ID",
         example = "1",
     )
-    @field:NotNull(message = "이동전 사진 ID 목록은 비어있을 수 없습니다.")
+    @field:NotNull(message = "이동전 폴더 ID는 필수입니다.")
     val sourceFolderId: Long?,
 
     @field:Schema(

--- a/src/main/kotlin/com/neki/photo/api/dto/FolderRequest.kt
+++ b/src/main/kotlin/com/neki/photo/api/dto/FolderRequest.kt
@@ -49,6 +49,7 @@ data class MovePhotosToFolderRequest(
         description = "이동하기 전 폴더 ID 없으면 null",
         example = "1",
     )
+    @field:NotNull(message = "이동전 사진 ID 목록은 비어있을 수 없습니다.")
     val sourceFolderId: Long?,
 
     @field:Schema(
@@ -66,13 +67,6 @@ data class MovePhotosToFolderRequest(
 )
 
 data class CopyPhotosToFolderRequest(
-    @field:Schema(
-        description = "복제하기 전 폴더 ID",
-        example = "1",
-    )
-    @field:NotNull(message = "복제전 폴더 ID는 비어있을 수 없습니다.")
-    val sourceFolderId: Long?,
-
     @field:Schema(
         description = "복제할 사진 ID 목록",
         example = "[1, 2, 3]",

--- a/src/main/kotlin/com/neki/photo/application/command/FolderCommand.kt
+++ b/src/main/kotlin/com/neki/photo/application/command/FolderCommand.kt
@@ -23,8 +23,4 @@ data class MovePhotosToFolderCommand(
     val targetFolderIds: List<Long>,
 )
 
-data class CopyPhotosToFolderCommand(
-    val userId: Long,
-    val photoIds: List<Long>,
-    val targetFolderIds: List<Long>,
-)
+data class CopyPhotosToFolderCommand(val userId: Long, val photoIds: List<Long>, val targetFolderIds: List<Long>)

--- a/src/main/kotlin/com/neki/photo/application/command/FolderCommand.kt
+++ b/src/main/kotlin/com/neki/photo/application/command/FolderCommand.kt
@@ -18,14 +18,13 @@ data class RemovePhotosFromFolderCommand(val userId: Long, val folderId: Long, v
 
 data class MovePhotosToFolderCommand(
     val userId: Long,
-    val sourceFolderId: Long?,
+    val sourceFolderId: Long,
     val photoIds: List<Long>,
     val targetFolderIds: List<Long>,
 )
 
 data class CopyPhotosToFolderCommand(
     val userId: Long,
-    val sourceFolderId: Long,
     val photoIds: List<Long>,
     val targetFolderIds: List<Long>,
 )

--- a/src/main/kotlin/com/neki/photo/application/usecase/CopyPhotosToFolderUseCase.kt
+++ b/src/main/kotlin/com/neki/photo/application/usecase/CopyPhotosToFolderUseCase.kt
@@ -20,10 +20,6 @@ class CopyPhotosToFolderUseCase(
 
     @Transactional
     fun execute(command: CopyPhotosToFolderCommand) {
-        // source 폴더 소유권 확인
-        folderRepository.getOwnedFolder(command.userId, command.sourceFolderId)
-            ?: throw BusinessException(ResultCode.NOT_FOUND)
-
         // target 폴더 소유권 확인
         val ownedFolders: List<Folder> = folderRepository.getOwnedFolders(command.userId, command.targetFolderIds)
 

--- a/src/main/kotlin/com/neki/photo/application/usecase/MovePhotosToFolderUseCase.kt
+++ b/src/main/kotlin/com/neki/photo/application/usecase/MovePhotosToFolderUseCase.kt
@@ -21,10 +21,8 @@ class MovePhotosToFolderUseCase(
     @Transactional
     fun execute(command: MovePhotosToFolderCommand) {
         // source 폴더 소유권 확인
-        command.sourceFolderId?.let {
-            folderRepository.getOwnedFolder(command.userId, it)
-                ?: throw BusinessException(ResultCode.NOT_FOUND)
-        }
+        folderRepository.getOwnedFolder(command.userId, command.sourceFolderId)
+            ?: throw BusinessException(ResultCode.NOT_FOUND)
 
         // target 폴더 소유권 확인
         val ownedFolders: List<Folder> = folderRepository.getOwnedFolders(command.userId, command.targetFolderIds)

--- a/src/test/kotlin/com/neki/e2e/photo/folder/CopyPhotosToFolderE2ETest.kt
+++ b/src/test/kotlin/com/neki/e2e/photo/folder/CopyPhotosToFolderE2ETest.kt
@@ -56,7 +56,6 @@ class CopyPhotosToFolderE2ETest : PhotoImageE2ETestBase() {
         givenAuthenticated()
             .body(
                 CopyPhotosToFolderRequest(
-                    sourceFolderId = sourceFolder.id,
                     photoIds = listOf(photo.id!!),
                     targetFolderIds = listOf(targetFolder.id!!),
                 ),
@@ -94,7 +93,6 @@ class CopyPhotosToFolderE2ETest : PhotoImageE2ETestBase() {
         givenAuthenticated()
             .body(
                 CopyPhotosToFolderRequest(
-                    sourceFolderId = sourceFolder.id,
                     photoIds = listOf(photo1.id!!, photo2.id!!, photo3.id!!),
                     targetFolderIds = listOf(targetFolder.id!!),
                 ),
@@ -125,7 +123,6 @@ class CopyPhotosToFolderE2ETest : PhotoImageE2ETestBase() {
         givenAuthenticated()
             .body(
                 CopyPhotosToFolderRequest(
-                    sourceFolderId = folder.id,
                     photoIds = listOf(photo.id!!),
                     targetFolderIds = listOf(folder.id!!),
                 ),
@@ -152,7 +149,6 @@ class CopyPhotosToFolderE2ETest : PhotoImageE2ETestBase() {
         val photo = createPhotoImage(userId = testUser.id!!, mediaId = media.id!!, folderId = sourceFolder.id)
 
         val request = CopyPhotosToFolderRequest(
-            sourceFolderId = sourceFolder.id,
             photoIds = listOf(photo.id!!),
             targetFolderIds = listOf(targetFolder.id!!),
         )
@@ -188,30 +184,6 @@ class CopyPhotosToFolderE2ETest : PhotoImageE2ETestBase() {
     // ===================
 
     @Test
-    @DisplayName("존재하지 않는 source 폴더로 요청 시 400 에러를 반환한다")
-    fun givenNonExistentSourceFolder_whenCopy_thenReturnsNotFound() {
-        // Given
-        val targetFolder = folderRepository.save(Folder(userId = testUser.id!!, name = "타겟 폴더"))
-        val media = createMedia(ownerId = testUser.id!!, status = MediaStatus.UPLOADED)
-        val photo = createPhotoImage(userId = testUser.id!!, mediaId = media.id!!)
-
-        // When & Then
-        givenAuthenticated()
-            .body(
-                CopyPhotosToFolderRequest(
-                    sourceFolderId = 99999L,
-                    photoIds = listOf(photo.id!!),
-                    targetFolderIds = listOf(targetFolder.id!!),
-                ),
-            )
-            .`when`()
-            .post("/api/folders/photos/copy")
-            .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value())
-            .body("resultCode", equalTo(ResultCode.NOT_FOUND.code))
-    }
-
-    @Test
     @DisplayName("존재하지 않는 target 폴더로 요청 시 400 에러를 반환한다")
     fun givenNonExistentTargetFolder_whenCopy_thenReturnsNotFound() {
         // Given
@@ -223,35 +195,8 @@ class CopyPhotosToFolderE2ETest : PhotoImageE2ETestBase() {
         givenAuthenticated()
             .body(
                 CopyPhotosToFolderRequest(
-                    sourceFolderId = sourceFolder.id,
                     photoIds = listOf(photo.id!!),
                     targetFolderIds = listOf(99999L),
-                ),
-            )
-            .`when`()
-            .post("/api/folders/photos/copy")
-            .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value())
-            .body("resultCode", equalTo(ResultCode.NOT_FOUND.code))
-    }
-
-    @Test
-    @DisplayName("다른 사용자의 source 폴더로 요청 시 400 에러를 반환한다")
-    fun givenOtherUserSourceFolder_whenCopy_thenReturnsNotFound() {
-        // Given
-        val (otherUser, _) = createTestUserAndToken(email = "other@example.com")
-        val otherFolder = folderRepository.save(Folder(userId = otherUser.id!!, name = "다른 사용자 폴더"))
-        val targetFolder = folderRepository.save(Folder(userId = testUser.id!!, name = "타겟 폴더"))
-        val media = createMedia(ownerId = testUser.id!!, status = MediaStatus.UPLOADED)
-        val photo = createPhotoImage(userId = testUser.id!!, mediaId = media.id!!)
-
-        // When & Then
-        givenAuthenticated()
-            .body(
-                CopyPhotosToFolderRequest(
-                    sourceFolderId = otherFolder.id,
-                    photoIds = listOf(photo.id!!),
-                    targetFolderIds = listOf(targetFolder.id!!),
                 ),
             )
             .`when`()
@@ -275,7 +220,6 @@ class CopyPhotosToFolderE2ETest : PhotoImageE2ETestBase() {
         givenAuthenticated()
             .body(
                 CopyPhotosToFolderRequest(
-                    sourceFolderId = sourceFolder.id,
                     photoIds = listOf(photo.id!!),
                     targetFolderIds = listOf(otherFolder.id!!),
                 ),
@@ -302,7 +246,6 @@ class CopyPhotosToFolderE2ETest : PhotoImageE2ETestBase() {
         givenAuthenticated()
             .body(
                 CopyPhotosToFolderRequest(
-                    sourceFolderId = sourceFolder.id,
                     photoIds = listOf(otherUserPhoto.id!!),
                     targetFolderIds = listOf(targetFolder.id!!),
                 ),
@@ -325,7 +268,6 @@ class CopyPhotosToFolderE2ETest : PhotoImageE2ETestBase() {
         givenAuthenticated()
             .body(
                 CopyPhotosToFolderRequest(
-                    sourceFolderId = sourceFolder.id,
                     photoIds = emptyList(),
                     targetFolderIds = listOf(targetFolder.id!!),
                 ),
@@ -354,7 +296,6 @@ class CopyPhotosToFolderE2ETest : PhotoImageE2ETestBase() {
         givenAuthenticated()
             .body(
                 CopyPhotosToFolderRequest(
-                    sourceFolderId = sourceFolder.id,
                     photoIds = listOf(photoNotInSource.id!!),
                     targetFolderIds = listOf(targetFolder.id!!),
                 ),
@@ -388,7 +329,6 @@ class CopyPhotosToFolderE2ETest : PhotoImageE2ETestBase() {
         givenAuthenticated()
             .body(
                 CopyPhotosToFolderRequest(
-                    sourceFolderId = sourceFolder.id,
                     photoIds = listOf(photo1.id!!, photo2.id!!),
                     targetFolderIds = listOf(targetFolder.id!!),
                 ),
@@ -424,7 +364,6 @@ class CopyPhotosToFolderE2ETest : PhotoImageE2ETestBase() {
         givenAuthenticated()
             .body(
                 CopyPhotosToFolderRequest(
-                    sourceFolderId = sourceFolder.id,
                     photoIds = listOf(copyingPhoto.id!!),
                     targetFolderIds = listOf(targetFolder.id!!),
                 ),
@@ -458,7 +397,6 @@ class CopyPhotosToFolderE2ETest : PhotoImageE2ETestBase() {
         givenAuthenticated()
             .body(
                 CopyPhotosToFolderRequest(
-                    sourceFolderId = sourceFolder.id,
                     photoIds = listOf(photo.id!!),
                     targetFolderIds = listOf(targetFolder.id!!),
                 ),
@@ -490,7 +428,6 @@ class CopyPhotosToFolderE2ETest : PhotoImageE2ETestBase() {
         givenAuthenticated()
             .body(
                 CopyPhotosToFolderRequest(
-                    sourceFolderId = sourceFolder.id,
                     photoIds = listOf(photo.id!!),
                     targetFolderIds = listOf(targetFolder.id!!),
                 ),
@@ -526,7 +463,6 @@ class CopyPhotosToFolderE2ETest : PhotoImageE2ETestBase() {
         givenAuthenticated()
             .body(
                 CopyPhotosToFolderRequest(
-                    sourceFolderId = sourceFolder.id,
                     photoIds = listOf(photo1.id!!),
                     targetFolderIds = listOf(targetFolder.id!!),
                 ),
@@ -540,7 +476,6 @@ class CopyPhotosToFolderE2ETest : PhotoImageE2ETestBase() {
         givenAuthenticated()
             .body(
                 CopyPhotosToFolderRequest(
-                    sourceFolderId = sourceFolder.id,
                     photoIds = listOf(photo1.id!!, photo2.id!!),
                     targetFolderIds = listOf(targetFolder.id!!),
                 ),


### PR DESCRIPTION
## Summary

- 사진 수정 및 복제에 대한 API 를 수정합니다.

## Changes
아래 기획에 따른 API 수정을 진행합니다.

**사진 복제 (sourceFolderId 필요 X)**
- 폴더에서 폴더
- 무폴더에서 폴더 (e.g 사진 상세)
- 사진 상세에서 앨범에 추가 = 사진 복제

**사진 이동 (sourceFolderId 필수)**
- 폴더에서 폴더

- [x] 사진 복제의 경우 sourceFolderId 가 필요없으므로 Request 파라미터에서 제외 단순 복제만 진행
- [x] 사진 이동의 경우 sourceFolderId 가 필수이므로 Request 파라미터에 필수 조건 추가 

## Related Issue
#279 